### PR TITLE
[F] Method not found error when migrating with old HeadlessLoader.dll

### DIFF
--- a/AquaMai.Config/Migration/ConfigMigrationManager.cs
+++ b/AquaMai.Config/Migration/ConfigMigrationManager.cs
@@ -38,7 +38,7 @@ public class ConfigMigrationManager : IConfigMigrationManager
         {
             var migration = migrationMap[currentVersion];
             Utility.Log($"Migrating config from v{migration.FromVersion} to v{migration.ToVersion}");
-            config = migration.Migrate(config);
+            config = migration.Migrate((ConfigView)config);
             currentVersion = migration.ToVersion;
         }
 

--- a/AquaMai.Config/Migration/ConfigMigration_V1_0_V2_0.cs
+++ b/AquaMai.Config/Migration/ConfigMigration_V1_0_V2_0.cs
@@ -10,7 +10,7 @@ public class ConfigMigration_V1_0_V2_0 : IConfigMigration
     public string FromVersion => "1.0";
     public string ToVersion => "2.0";
 
-    public IConfigView Migrate(IConfigView src)
+    public ConfigView Migrate(ConfigView src)
     {
         var dst = new ConfigView();
 

--- a/AquaMai.Config/Migration/ConfigMigration_V2_0_V2_1.cs
+++ b/AquaMai.Config/Migration/ConfigMigration_V2_0_V2_1.cs
@@ -8,9 +8,9 @@ public class ConfigMigration_V2_0_V2_1 : IConfigMigration
     public string FromVersion => "2.0";
     public string ToVersion => "2.1";
 
-    public IConfigView Migrate(IConfigView src)
+    public ConfigView Migrate(ConfigView src)
     {
-        var dst = src.Clone();
+        var dst = (ConfigView)src.Clone();
         dst.SetValue("Version", ToVersion);
 
         if (src.IsSectionEnabled("Tweaks.ResetTouchAfterTrack"))

--- a/AquaMai.Config/Migration/ConfigMigration_V2_1_V2_2.cs
+++ b/AquaMai.Config/Migration/ConfigMigration_V2_1_V2_2.cs
@@ -8,9 +8,9 @@ public class ConfigMigration_V2_1_V2_2 : IConfigMigration
     public string FromVersion => "2.1";
     public string ToVersion => "2.2";
 
-    public IConfigView Migrate(IConfigView src)
+    public ConfigView Migrate(ConfigView src)
     {
-        var dst = src.Clone();
+        var dst = (ConfigView)src.Clone();
         dst.SetValue("Version", ToVersion);
 
         if (src.IsSectionEnabled("GameSystem.Assets.UseJacketAsDummyMovie"))

--- a/AquaMai.Config/Migration/IConfigMigration.cs
+++ b/AquaMai.Config/Migration/IConfigMigration.cs
@@ -6,5 +6,5 @@ public interface IConfigMigration
 {
     public string FromVersion { get; }
     public string ToVersion { get; }
-    public IConfigView Migrate(IConfigView config);
+    public ConfigView Migrate(ConfigView config);
 }


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过将 Migrate 方法签名更改为使用 ConfigView 而不是 IConfigView 来修复方法未找到错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix method not found error by changing the Migrate method signature to use ConfigView instead of IConfigView.

</details>