### PR TITLE
[F] Cannot clone ConfigView created by `new ConfigView()`

### DIFF
--- a/AquaMai.Config/ConfigView.cs
+++ b/AquaMai.Config/ConfigView.cs
@@ -12,7 +12,7 @@ public class ConfigView : IConfigView
 
     public ConfigView()
     {
-        root = new TomlTable();
+        root = TomlDocument.CreateEmpty();
     }
 
     public ConfigView(TomlTable root)


### PR DESCRIPTION
看来 `new TomlTable()` 不能直接 `.SerializedValue`，会提示 `Cannot use SerializeValue to serialize non-inline tables. Use SerializeNonInlineTable(keyName)`

## Summary by Sourcery

错误修复：
- 通过用 `TomlDocument.CreateEmpty()` 替换 `TomlTable`，修复了由于无法序列化非内联表而导致 `ConfigView` 无法克隆的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the issue where a ConfigView cannot be cloned due to the inability to serialize non-inline tables by replacing TomlTable with TomlDocument.CreateEmpty().

</details>