### PR TITLE
[F] Fixed the issue that the game crashed when entering the rank recognition mode

### DIFF
--- a/AquaMai.Mods/Fix/Common.cs
+++ b/AquaMai.Mods/Fix/Common.cs
@@ -144,7 +144,7 @@ public class Common
     }
 
     [ConfigEntry]
-    private readonly static bool enableAllEvent = true;
+    private readonly static bool enableAllEvent = false; // 如果这个值是true，则段位认定无法使用（会崩溃）
 
     [EnableIf(nameof(enableAllEvent))]
     [HarmonyPrefix]


### PR DESCRIPTION
试图修复在新版本AquaMai中会发生的进入段位认定模式会崩溃的问题。
测试HDD版本SDGA1.50-A。

## Summary by Sourcery

Bug 修复：
- 修复了在 AquaMai 中进入排名识别模式时发生的崩溃问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixed a crash that occurred when entering rank recognition mode in AquaMai.

</details>