### PR TITLE
[F] Fix derakkuma stops dancing in DisableTimeout

### DIFF
--- a/AquaMai.Mods/GameSystem/DisableTimeout.cs
+++ b/AquaMai.Mods/GameSystem/DisableTimeout.cs
@@ -9,6 +9,7 @@ using Monitor;
 using Process;
 using Process.Entry.State;
 using Process.ModeSelect;
+using UnityEngine.Playables;
 
 namespace AquaMai.Mods.GameSystem;
 
@@ -80,5 +81,15 @@ public class DisableTimeout
         SoundManager.PlaySE(Mai2.Mai2Cue.Cue.SE_SYS_SKIP, 0);
         ____monitors[0].SetButtonPressed(InputManager.ButtonSetting.Button04);
         Traverse.Create(__instance).Method("OnTimeUp").GetValue();
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(ContinueMonitor), "Initialize")]
+    public static void ContinueMonitorInitialize(PlayableDirector ____director)
+    {
+        if (____director != null)
+        {
+            ____director.extrapolationMode = DirectorWrapMode.Loop;
+        }
     }
 }

--- a/AquaMai.Mods/GameSystem/DisableTimeout.cs
+++ b/AquaMai.Mods/GameSystem/DisableTimeout.cs
@@ -92,4 +92,14 @@ public class DisableTimeout
             ____director.extrapolationMode = DirectorWrapMode.Loop;
         }
     }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(ContinueMonitor), "PlayContinue")]
+    public static void ContinueMonitorPlayContinue(PlayableDirector ____director)
+    {
+        if (____director != null)
+        {
+            ____director.extrapolationMode = DirectorWrapMode.Hold;
+        }
+    }
 }


### PR DESCRIPTION
## Summary by Sourcery

Bug 修复：
- 修复了在继续屏幕超时期间 Derakkuma 停止跳舞的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where Derakkuma would stop dancing during the continue screen timeout.

</details>
- 修复了在继续屏幕超时期间 Derakkuma 停止跳舞的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug 修复：
- 修复了在继续屏幕超时期间 Derakkuma 停止跳舞的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where Derakkuma would stop dancing during the continue screen timeout.

</details>

</details>