### PR TITLE
让trackNumber可以显示2位数字

### DIFF
--- a/AquaMai.Mods/Fix/FixTrackNumDisplay.cs
+++ b/AquaMai.Mods/Fix/FixTrackNumDisplay.cs
@@ -126,10 +126,10 @@ public class FixTrackNumDisplay
 
             // 数字1的位置需要额外调整，以保证视觉上与其它数字间距一致
             // currentTrackNum 第一位
-            if (curStr[0] == '1' && TrackNumDisplayStyle != 2)
+            if (curStr[0] == '1' && curStr[1] != ' ')
                 ____trackCountText.FrameList[0].RelativePosition = new Vector2(5+2, 0);
             // currentTrackNum 第二位
-            if (curStr[1] == '1' && TrackNumDisplayStyle != 0)
+            if (curStr[1] == '1' && curStr[0] != ' ')
                 ____trackCountText.FrameList[1].RelativePosition = new Vector2(-7-2, 0);
             // maxTrackNum 第一位
             if (maxStr[0] == '1')

--- a/AquaMai.Mods/Fix/FixTrackNumDisplay.cs
+++ b/AquaMai.Mods/Fix/FixTrackNumDisplay.cs
@@ -105,39 +105,44 @@ public class FixTrackNumDisplay
                 ____trackCountText.FrameList[1].Scale = 0.4f;
                 ____trackDenominatortText.FrameList[0].Scale = 0.3f;
                 ____trackDenominatortText.FrameList[1].Scale = 0.3f;
-                // 调整文字位置
-                ____trackCountText.FrameList[0].RelativePosition = new Vector2(5, 0);
-                ____trackCountText.FrameList[1].RelativePosition = new Vector2(-7, 0);
-                ____trackDenominatortText.FrameList[0].RelativePosition = new Vector2(33, 0);
-                ____trackDenominatortText.FrameList[1].RelativePosition = new Vector2(16, 0);
-
-                // 数字1的位置需要额外调整，以保证视觉上与其它数字间距一致
-                var curStr = currentTrackNum.ToString();
-                var maxStr = maxTrackNum.ToString();
-                // currentTrackNum 第一位
-                if (curStr.Length == 2 && curStr[0] == '1') ____trackCountText.FrameList[0].RelativePosition = new Vector2(5+2, 0);
-                // currentTrackNum 第二位
-                if (curStr.Length == 1 && curStr[0] == '1') ____trackCountText.FrameList[1].RelativePosition = new Vector2(-7-2, 0);
-                if (curStr.Length == 2 && curStr[1] == '1') ____trackCountText.FrameList[1].RelativePosition = new Vector2(-7-2, 0);
-                // maxTrackNum 第一位
-                if (maxStr.Length == 2 && maxStr[0] == '1') ____trackDenominatortText.FrameList[0].RelativePosition = new Vector2(33+2, 0);                
-                // maxTrackNum 第二位
-                if (maxStr.Length == 1 && maxStr[0] == '1') ____trackDenominatortText.FrameList[1].RelativePosition = new Vector2(16-2, 0);
-                if (maxStr.Length == 2 && maxStr[1] == '1') ____trackDenominatortText.FrameList[1].RelativePosition = new Vector2(16-2, 0);
             }
 
-            string content = TrackNumDisplayStyle switch {
-                0 => currentTrackNum.ToString().PadLeft(2),      //左侧空格补位
-                1 => currentTrackNum.ToString().PadLeft(2, '0'), //左侧零补位
-                2 => currentTrackNum.ToString().PadRight(2),     //右侧空格补位
-                _ => currentTrackNum.ToString().PadLeft(2),      //默认 case 0
+            var curStr = currentTrackNum.ToString();
+            var maxStr = maxTrackNum.ToString();
+
+            // 根据配置选择显示格式
+            curStr = TrackNumDisplayStyle switch {
+                0 => curStr.PadLeft(2),      //左侧空格补位
+                1 => curStr.PadLeft(2, '0'), //左侧零补位
+                2 => curStr.PadRight(2),     //右侧空格补位
+                _ => curStr.PadLeft(2),      //默认 case 0
             };
+
+            // 默认文字位置
+            ____trackCountText.FrameList[0].RelativePosition = new Vector2(5, 0);
+            ____trackCountText.FrameList[1].RelativePosition = new Vector2(-7, 0);
+            ____trackDenominatortText.FrameList[0].RelativePosition = new Vector2(33, 0);
+            ____trackDenominatortText.FrameList[1].RelativePosition = new Vector2(16, 0);
+
+            // 数字1的位置需要额外调整，以保证视觉上与其它数字间距一致
+            // currentTrackNum 第一位
+            if (curStr[0] == '1' && TrackNumDisplayStyle != 2)
+                ____trackCountText.FrameList[0].RelativePosition = new Vector2(5+2, 0);
+            // currentTrackNum 第二位
+            if (curStr[1] == '1' && TrackNumDisplayStyle != 0)
+                ____trackCountText.FrameList[1].RelativePosition = new Vector2(-7-2, 0);
+            // maxTrackNum 第一位
+            if (maxStr[0] == '1')
+                ____trackDenominatortText.FrameList[0].RelativePosition = new Vector2(33+2, 0);                
+            // maxTrackNum 第二位
+            if (maxStr[1] == '1')
+                ____trackDenominatortText.FrameList[1].RelativePosition = new Vector2(16-2, 0);
 
             // 复制原版处理非自由模式的逻辑
             var trackColorID = 0;
             ____trackMaskImage.SetActive(value: false);
-            ____trackCountText.ChangeText(content); // 使用自定义文本
-            ____trackDenominatortText.ChangeText(maxTrackNum.ToString());
+            ____trackCountText.ChangeText(curStr); // 使用自定义文本
+            ____trackDenominatortText.ChangeText(maxStr);
             trackColorID = (maxTrackNum - currentTrackNum) switch
             {
                 0u => 2, 

--- a/AquaMai.Mods/Fix/FixTrackNumDisplay.cs
+++ b/AquaMai.Mods/Fix/FixTrackNumDisplay.cs
@@ -14,11 +14,10 @@ namespace AquaMai.Mods.Fix;
     zh: "让右上角的当前曲目数字可以显示两位数")]
 public class FixTrackNumDisplay
 {
-    // 添加configentry
     [ConfigEntry(
-        en: "Use 0 prefix for track number",
-        zh: "在数字前添加 0 进行补位")]
-    private static readonly bool ZeroPrefix = true;
+        en: "Track number display style: 0=Left-padded (_5), 1=Zero-padded (05), 2=Right-padded (5_)",
+        zh: "曲目数字显示格式: 0=左侧补空格(_5), 1=左侧补零(05), 2=右侧补空格(5_)")]
+    private static readonly int TrackNumDisplayStyle = 0; // Default 0
 
     private static Sprite[] customSprites;
     private static bool isInitialized = false;
@@ -127,17 +126,17 @@ public class FixTrackNumDisplay
                 if (maxStr.Length == 2 && maxStr[1] == '1') ____trackDenominatortText.FrameList[1].RelativePosition = new Vector2(16-2, 0);
             }
 
-            string content;
-            if (ZeroPrefix) {
-                content = currentTrackNum.ToString().PadLeft(2, '0'); // 使用0补位
-            } else {
-                content = currentTrackNum.ToString().PadLeft(2); // 使用空格补位
-            }
+            string content = TrackNumDisplayStyle switch {
+                0 => currentTrackNum.ToString().PadLeft(2),      //左侧空格补位
+                1 => currentTrackNum.ToString().PadLeft(2, '0'), //左侧零补位
+                2 => currentTrackNum.ToString().PadRight(2),     //右侧空格补位
+                _ => currentTrackNum.ToString().PadLeft(2),      //默认 case 0
+            };
 
             // 复制原版处理非自由模式的逻辑
             var trackColorID = 0;
             ____trackMaskImage.SetActive(value: false);
-            ____trackCountText.ChangeText(content);
+            ____trackCountText.ChangeText(content); // 使用自定义文本
             ____trackDenominatortText.ChangeText(maxTrackNum.ToString());
             trackColorID = (maxTrackNum - currentTrackNum) switch
             {


### PR DESCRIPTION
## Sourcery 总结

新功能：
- 以两位数显示音轨编号，允许显示大于 9 的数字。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Display the track number with two digits, allowing for numbers greater than 9 to be shown.

</details>