### PR TITLE
feat: make float.Parse and int.Parse calls culture-invariant

### DIFF
--- a/AquaMai.Mods/Fix/ParseWithCultureInvariant.cs
+++ b/AquaMai.Mods/Fix/ParseWithCultureInvariant.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Reflection;
+using System.Reflection.Emit;
+using AquaMai.Config.Attributes;
+using HarmonyLib;
+using Manager;
+using Monitor;
+using Monitor.MapResult;
+using Monitor.MovieCheck;
+
+namespace AquaMai.Mods.Fix;
+
+[ConfigSection(exampleHidden: true, defaultOn: true)]
+public class ParseWithCultureInvariant
+{
+    [HarmonyPatch]
+    public class FixParseNumber
+    {
+        static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(typeof(SlideManager), "loadXML");
+            yield return AccessTools.Method(typeof(DebugLogCollector), "LoadCounter");
+            yield return AccessTools.Method(typeof(MenuCardObject), "SetVolume");
+            yield return AccessTools.Method(typeof(NaviCharaDebugView), "UpdateNaviChara");
+            yield return AccessTools.Method(typeof(SimpleSettingMonitor), "SetVolume");
+            yield return AccessTools.Method(
+                typeof(DLMusicScoreManager), "ExistsMusicScore", [typeof(string), typeof(int), typeof(string).MakeByRefType()]);
+            yield return AccessTools.Method(typeof(NotesReader), "loadHeader");
+            yield return AccessTools.Method(typeof(Manager.Version), "init");
+            yield return AccessTools.Method(typeof(MapStockController), "SetNumber");
+            yield return AccessTools.Method(typeof(TrackStartMonitor), "SetTrackStart");
+            yield return AccessTools.Method(typeof(BonusNumber), "SetNumber");
+            yield return AccessTools.Method(typeof(CharaLevelNumber), "SetNumber");
+            yield return AccessTools.Method(typeof(OdometerNumber), "SetNumber");
+            yield return AccessTools.Method(typeof(MovieCheckMonitor), "GetSelectDropDown");
+        }
+
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var instrs = new List<CodeInstruction>(instructions);
+            
+            var methodIntParse = AccessTools.Method(typeof(int), "Parse", [typeof(string)]);
+            var methodIntParseFull = AccessTools.Method(
+                typeof(int), "Parse", [typeof(string), typeof(NumberStyles), typeof(IFormatProvider)]);
+            var methodFloatParse = AccessTools.Method(typeof(float), "Parse", [typeof(string)]);
+            var methodFloatParseFull = AccessTools.Method(
+                typeof(float), "Parse", [typeof(string), typeof(NumberStyles), typeof(IFormatProvider)]);
+            var methodGetInvariantCulture = AccessTools.PropertyGetter(typeof(CultureInfo), "InvariantCulture");
+        
+            for (var i = 0; i < instrs.Count; i++)
+            {
+                var callsFloatParse = instrs[i].Calls(methodFloatParse);
+                var callsIntParse = instrs[i].Calls(methodIntParse);
+
+                if (!callsFloatParse && !callsIntParse)
+                {
+                    continue;
+                }
+
+                instrs.RemoveAt(i);
+                instrs.Insert(i, new CodeInstruction(OpCodes.Ldc_I4, (int)NumberStyles.Any));
+                instrs.Insert(i + 1, new CodeInstruction(OpCodes.Call, methodGetInvariantCulture));
+
+                if (callsFloatParse)
+                {
+                    instrs.Insert(i + 2, new CodeInstruction(OpCodes.Call, methodFloatParseFull));
+                }
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+                else if (callsIntParse)
+                {
+                    instrs.Insert(i + 2, new CodeInstruction(OpCodes.Call, methodIntParseFull));
+                }
+            }
+
+            return instrs;
+        }
+    }
+}


### PR DESCRIPTION
maimai's code is littered with `Int32.Parse(String)` and `Single.Parse(String)`, which uses the current system culture. This often breaks chart parsing on systems where the locale uses `,` for decimal separator and `.` for thousands separator (opposite of `ja-JP`).

This mod makes it so that these calls are replaced with `Int32.Parse(String, NumberStyles.All, CultureInfo.InvariantCulture)` and `Single.Parse(String, NumberStyles.All, CultureInfo.InvariantCulture)`, ensuring consistent parsing behavior on all locales.

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

替换了多个模块中对区域设置敏感的数字解析调用，改为使用固定区域性的重载，以确保在所有区域设置上行为一致。

Bug 修复：
- 通过在图表和 UI 代码路径中强制执行固定区域性的数字解析，修复了依赖于区域设置的解析错误。

增强功能：
- 引入了一个 Harmony 转译器，用于拦截并将 `int.Parse` 和 `float.Parse` 调用替换为目标方法中的 `NumberStyles.Any` 和 `CultureInfo.InvariantCulture` 重载。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace culture-sensitive number parsing calls with invariant-culture overloads across multiple modules to ensure consistent behavior on all locales.

Bug Fixes:
- Fix locale-dependent parsing errors by enforcing invariant-culture number parsing in chart and UI code paths.

Enhancements:
- Introduce a Harmony transpiler that intercepts and replaces int.Parse and float.Parse calls with NumberStyles.Any and CultureInfo.InvariantCulture overloads in targeted methods.

</details>