### PR TITLE
feat: FixLocaleIssues

### DIFF
--- a/AquaMai.Mods/Fix/FixLocaleIssues.cs
+++ b/AquaMai.Mods/Fix/FixLocaleIssues.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Threading;
 using AquaMai.Config.Attributes;
 using HarmonyLib;
 using JetBrains.Annotations;
@@ -17,6 +18,11 @@ public class FixLocaleIssues
 
     public static void OnBeforePatch()
     {
+        Thread.CurrentThread.CurrentCulture = JapanCultureInfo;
+        Thread.CurrentThread.CurrentUICulture = JapanCultureInfo;
+        CultureInfo.DefaultThreadCurrentCulture = JapanCultureInfo;
+        CultureInfo.DefaultThreadCurrentUICulture = JapanCultureInfo;
+        
         try
         {
             _tokyoStandardTime = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");

--- a/AquaMai.Mods/Fix/FixLocaleIssues.cs
+++ b/AquaMai.Mods/Fix/FixLocaleIssues.cs
@@ -18,11 +18,6 @@ public class FixLocaleIssues
 
     public static void OnBeforePatch()
     {
-        Thread.CurrentThread.CurrentCulture = JapanCultureInfo;
-        Thread.CurrentThread.CurrentUICulture = JapanCultureInfo;
-        CultureInfo.DefaultThreadCurrentCulture = JapanCultureInfo;
-        CultureInfo.DefaultThreadCurrentUICulture = JapanCultureInfo;
-        
         try
         {
             _tokyoStandardTime = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");
@@ -54,7 +49,7 @@ public class FixLocaleIssues
     [HarmonyPatch(typeof(NumberFormatInfo), "get_CurrentInfo")]
     public static bool NumberFormatInfo_get_CurrentInfo(ref NumberFormatInfo __result)
     {
-        __result = (NumberFormatInfo)JapanCultureInfo.GetFormat(typeof(NumberFormatInfo));
+        __result = JapanCultureInfo.NumberFormat;
         return false;
     }
 
@@ -63,7 +58,7 @@ public class FixLocaleIssues
     [HarmonyPatch(typeof(DateTimeFormatInfo), "get_CurrentInfo")]
     public static bool DateTimeFormatInfo_get_CurrentInfo(ref DateTimeFormatInfo __result)
     {
-        __result = (DateTimeFormatInfo)JapanCultureInfo.GetFormat(typeof(DateTimeFormatInfo));
+        __result = JapanCultureInfo.DateTimeFormat;
         return false;
     }
     

--- a/AquaMai.Mods/Fix/FixLocaleIssues.cs
+++ b/AquaMai.Mods/Fix/FixLocaleIssues.cs
@@ -60,7 +60,7 @@ public class FixLocaleIssues
     }
 
     [HarmonyPrefix]
-    [HarmonyPatch(typeof(DateTime), "Parse")]
+    [HarmonyPatch(typeof(DateTime), "Parse", typeof(string))]
     private static bool DateTime_Parse(ref DateTime __result, string s)
     {
         __result = DateTime.Parse(s, JapanCultureInfo);

--- a/AquaMai.Mods/Fix/FixLocaleIssues.cs
+++ b/AquaMai.Mods/Fix/FixLocaleIssues.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Globalization;
+using AquaMai.Config.Attributes;
+using HarmonyLib;
+using JetBrains.Annotations;
+using Manager;
+
+namespace AquaMai.Mods.Fix;
+
+// Fixes various locale issues that pop up if the game runs in a different locale than ja-JP.
+[ConfigSection(exampleHidden: true, defaultOn: true)]
+public class FixLocaleIssues
+{
+    private static readonly CultureInfo JapanCultureInfo = new CultureInfo("ja-JP");
+    [CanBeNull] private static TimeZoneInfo _tokyoStandardTime;
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(int), "Parse", typeof(string))]
+    private static bool int_Parse(ref int __result, string s)
+    {
+        __result = int.Parse(s, JapanCultureInfo);
+        return false;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(float), "Parse", typeof(string))]
+    private static bool float_Parse(ref float __result, string s)
+    {
+        __result = float.Parse(s, JapanCultureInfo);
+        return false;
+    }
+    
+    // Forces local timezone to be UTC+9, since segatools didn't patch it properly until recent versions,
+    // which doesn't actually work well with maimai.
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(DateTime), "get_Now")]
+    private static bool DateTime_get_Now(ref DateTime __result)
+    {
+        if (_tokyoStandardTime == null)
+        {
+            try
+            {
+                _tokyoStandardTime = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");
+            }
+            catch (Exception e) when (e is TimeZoneNotFoundException or InvalidTimeZoneException)
+            {
+                _tokyoStandardTime = TimeZoneInfo.CreateCustomTimeZone(
+                    "Tokyo Standard Time",
+                    TimeManager.JpTime,
+                    "(UTC+09:00) Osaka, Sapporo, Tokyo",
+                    "Tokyo Standard Time",
+                    "Tokyo Daylight Time",
+                    null,
+                    true);
+            }
+        }
+
+        __result = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, _tokyoStandardTime!);
+        return false;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(DateTime), "Parse")]
+    private static bool DateTime_Parse(ref DateTime __result, string s)
+    {
+        __result = DateTime.Parse(s, JapanCultureInfo);
+        return false;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(DateTime), "ToShortDateString")]
+    private static bool DateTime_ToShortDateString(DateTime __instance, ref string __result)
+    {
+        __result = __instance.ToString("d", JapanCultureInfo);
+        return false;
+    }
+}

--- a/AquaMai.Mods/Fix/FixLocaleIssues.cs
+++ b/AquaMai.Mods/Fix/FixLocaleIssues.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Threading;
 using AquaMai.Config.Attributes;
 using HarmonyLib;
 using JetBrains.Annotations;
@@ -19,6 +20,8 @@ public class FixLocaleIssues
     {
         CultureInfo.DefaultThreadCurrentCulture = JapanCultureInfo;
         CultureInfo.DefaultThreadCurrentUICulture = JapanCultureInfo;
+        Thread.CurrentThread.CurrentCulture = JapanCultureInfo;
+        Thread.CurrentThread.CurrentUICulture = JapanCultureInfo;
 
         try
         {


### PR DESCRIPTION
Patches a few locale-dependent system functions to always use the Japanese locale, which is what the game expects. Also forces `DateTime.Now` to return UTC+9.

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

修复了依赖于区域设置的解析和格式化方法，以始终使用日语区域设置，并强制 DateTime.Now 使用东京（UTC+9）时间。

Bug 修复：
- 修复了 int.Parse 和 float.Parse 以使用 ja-JP 区域设置。
- 重写了 DateTime.Parse 和 ToShortDateString 以使用日语区域设置进行格式化。
- 强制 DateTime.Now getter 通过东京标准时间返回 UTC+9 时间，如果不可用，则创建自定义时区。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Patch locale-dependent parsing and formatting methods to consistently use the Japanese locale and force DateTime.Now to Tokyo (UTC+9) time.

Bug Fixes:
- Patch int.Parse and float.Parse to use ja-JP locale.
- Override DateTime.Parse and ToShortDateString to format with Japanese locale.
- Force DateTime.Now getter to return UTC+9 time via Tokyo Standard Time, creating a custom timezone if unavailable.

</details>