### PR TITLE
[+] New mod GameSystem.SkipBoardNoCheck

### DIFF
--- a/AquaMai.Mods/GameSystem/SkipBoardNoCheck.cs
+++ b/AquaMai.Mods/GameSystem/SkipBoardNoCheck.cs
@@ -22,30 +22,25 @@ public class SkipBoardNoCheck
     {
         var codes = new List<CodeInstruction>(instructions);
         bool patched = false;
-
         for (int i = 0; i < codes.Count; i++)
         {
             if (codes[i].opcode == OpCodes.Callvirt &&
                 codes[i].operand != null &&
                 codes[i].operand.ToString().Contains("IsEqual"))
             {
-                codes.Insert(i, new CodeInstruction(OpCodes.Pop));
-                codes.Insert(i, new CodeInstruction(OpCodes.Pop));
-                codes.Insert(i, new CodeInstruction(OpCodes.Ldc_I4_1));
+                codes[i] = new CodeInstruction(OpCodes.Pop);
+                codes.Insert(i + 1, new CodeInstruction(OpCodes.Pop));
+                codes.Insert(i + 2, new CodeInstruction(OpCodes.Ldc_I4_1));
+
                 patched = true;
+                MelonLoader.MelonLogger.Msg("[SkipBoardNoCheck] 修补 BoardCtrl15070_4._md_initBoard_GetBoardInfo 方法成功");
                 break;
             }
         }
-
-        if (patched)
+        if (!patched)
         {
-            MelonLoader.MelonLogger.Msg("修补 BoardCtrl15070_4._md_initBoard_GetBoardInfo 方法成功");
+            MelonLoader.MelonLogger.Warning("[SkipBoardNoCheck] 未找到需要修补的代码位置：BoardCtrl15070_4._md_initBoard_GetBoardInfo");
         }
-        else
-        {
-            MelonLoader.MelonLogger.Warning("未找到需要修补的代码位置：BoardCtrl15070_4._md_initBoard_GetBoardInfo");
-        }
-
         return codes;
     }
 
@@ -55,30 +50,25 @@ public class SkipBoardNoCheck
     {
         var codes = new List<CodeInstruction>(instructions);
         bool patched = false;
-
         for (int i = 0; i < codes.Count; i++)
         {
             if (codes[i].opcode == OpCodes.Callvirt &&
                 codes[i].operand != null &&
                 codes[i].operand.ToString().Contains("IsEqual"))
             {
-                codes.Insert(i, new CodeInstruction(OpCodes.Pop));
-                codes.Insert(i, new CodeInstruction(OpCodes.Pop));
-                codes.Insert(i, new CodeInstruction(OpCodes.Ldc_I4_1));
+                codes[i] = new CodeInstruction(OpCodes.Pop);
+                codes.Insert(i + 1, new CodeInstruction(OpCodes.Pop));
+                codes.Insert(i + 2, new CodeInstruction(OpCodes.Ldc_I4_1));
+
                 patched = true;
+                MelonLoader.MelonLogger.Msg("[SkipBoardNoCheck] 修补 Bd15070_4Control.IsNeedFirmUpdate 方法成功");
                 break;
             }
         }
-
-        if (patched)
+        if (!patched)
         {
-            MelonLoader.MelonLogger.Msg("修补 Bd15070_4Control.IsNeedFirmUpdate 方法成功");
+            MelonLoader.MelonLogger.Warning("[SkipBoardNoCheck] 未找到需要修补的代码位置：Bd15070_4Control.IsNeedFirmUpdate");
         }
-        else
-        {
-            MelonLoader.MelonLogger.Warning("未找到需要修补的代码位置：Bd15070_4Control.IsNeedFirmUpdate");
-        }
-
         return codes;
     }
 }

--- a/AquaMai.Mods/GameSystem/SkipBoardNoCheck.cs
+++ b/AquaMai.Mods/GameSystem/SkipBoardNoCheck.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using AMDaemon;
+using AquaMai.Config.Attributes;
+using Comio.BD15070_4;
+using Mecha;
+using HarmonyLib;
+using System.Reflection.Emit;
+using Manager;
+using UnityEngine;
+
+namespace AquaMai.Mods.GameSystem;
+
+[ConfigSection(
+    en: "Skip BoardNo check to use the old cab light board 837-15070-02",
+    zh: "跳过 BoardNo 检查以使用 837-15070-02（旧框灯板）")]
+public class SkipBoardNoCheck
+{
+    [HarmonyTranspiler]
+    [HarmonyPatch(typeof(BoardCtrl15070_4), "_md_initBoard_GetBoardInfo")]
+    static IEnumerable<CodeInstruction> Transpiler1(IEnumerable<CodeInstruction> instructions)
+    {
+        var codes = new List<CodeInstruction>(instructions);
+        bool patched = false;
+
+        for (int i = 0; i < codes.Count; i++)
+        {
+            if (codes[i].opcode == OpCodes.Callvirt &&
+                codes[i].operand != null &&
+                codes[i].operand.ToString().Contains("IsEqual"))
+            {
+                codes.Insert(i, new CodeInstruction(OpCodes.Pop));
+                codes.Insert(i, new CodeInstruction(OpCodes.Pop));
+                codes.Insert(i, new CodeInstruction(OpCodes.Ldc_I4_1));
+                patched = true;
+                break;
+            }
+        }
+
+        if (patched)
+        {
+            MelonLoader.MelonLogger.Msg("修补 BoardCtrl15070_4._md_initBoard_GetBoardInfo 方法成功");
+        }
+        else
+        {
+            MelonLoader.MelonLogger.Warning("未找到需要修补的代码位置：BoardCtrl15070_4._md_initBoard_GetBoardInfo");
+        }
+
+        return codes;
+    }
+
+    [HarmonyTranspiler]
+    [HarmonyPatch(typeof(Bd15070_4Control), "IsNeedFirmUpdate")]
+    static IEnumerable<CodeInstruction> Transpiler2(IEnumerable<CodeInstruction> instructions)
+    {
+        var codes = new List<CodeInstruction>(instructions);
+        bool patched = false;
+
+        for (int i = 0; i < codes.Count; i++)
+        {
+            if (codes[i].opcode == OpCodes.Callvirt &&
+                codes[i].operand != null &&
+                codes[i].operand.ToString().Contains("IsEqual"))
+            {
+                codes.Insert(i, new CodeInstruction(OpCodes.Pop));
+                codes.Insert(i, new CodeInstruction(OpCodes.Pop));
+                codes.Insert(i, new CodeInstruction(OpCodes.Ldc_I4_1));
+                patched = true;
+                break;
+            }
+        }
+
+        if (patched)
+        {
+            MelonLoader.MelonLogger.Msg("修补 Bd15070_4Control.IsNeedFirmUpdate 方法成功");
+        }
+        else
+        {
+            MelonLoader.MelonLogger.Warning("未找到需要修补的代码位置：Bd15070_4Control.IsNeedFirmUpdate");
+        }
+
+        return codes;
+    }
+}

--- a/AquaMai/configSort.yaml
+++ b/AquaMai/configSort.yaml
@@ -88,6 +88,7 @@
   - GameSystem.RemoveEncryption
   - GameSystem.TouchPanelBaudRate
   - GameSystem.OptionLoadFix
+  - GameSystem.SkipBoardNoCheck
   - UX.ServerAnnouncement
   - Tweaks.SkipUserVersionCheck
   - Fancy.Triggers


### PR DESCRIPTION
Skip "BoardNo check" to use the old cab light board 837-15070-02 on Sinmai. Tested. Use [HarmonyTranspiler].

## Sourcery 总结

添加一个新的 GameSystem.SkipBoardNoCheck mod，该mod使用 Harmony transpilers 来覆盖电路板验证和固件更新检查，从而支持旧版 837-15070-02 驾驶室灯板。

新功能:
- 引入 SkipBoardNoCheck mod，以绕过旧版驾驶室灯板 837-15070-02 的 BoardNo 检查
- 实现 Harmony transpiler 补丁，强制使 BoardCtrl15070_4._md_initBoard_GetBoardInfo 和 Bd15070_4Control.IsNeedFirmUpdate 成功

改进:
- 在 configSort.yaml 的 mod 加载顺序中添加 SkipBoardNoCheck 条目

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new GameSystem.SkipBoardNoCheck mod that uses Harmony transpilers to override board validation and firmware update checks, enabling support for the legacy 837-15070-02 cab light board.

New Features:
- Introduce SkipBoardNoCheck mod to bypass BoardNo checks for the old cab light board 837-15070-02
- Implement Harmony transpiler patches to force success in BoardCtrl15070_4._md_initBoard_GetBoardInfo and Bd15070_4Control.IsNeedFirmUpdate

Enhancements:
- Add SkipBoardNoCheck entry to the mod load order in configSort.yaml

</details>