### PR TITLE
feat: Display error frame when specific hardware is not available.

### DIFF
--- a/AquaMai.Core/Helpers/ErrorFrame.cs
+++ b/AquaMai.Core/Helpers/ErrorFrame.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using HarmonyLib;
+using Manager;
+using MelonLoader;
+using Monitor.Error;
+using Process;
+using Process.Error;
+using TMPro;
+
+namespace AquaMai.Core.Helpers;
+
+public static class ErrorFrame
+{
+    private static int _customErrCode;
+    private static string _customErrMsg;
+    private static DateTime _customErrDate;
+    
+    public static void Show(ProcessBase process, int errCode, string errMsg)
+    {
+        _customErrCode = errCode;
+        _customErrMsg = errMsg;
+        _customErrDate = DateTime.Now;
+        Show(process);
+    }
+    
+    // Display the error frame with AMDaemon's original error message.
+    public static void Show(ProcessBase process)
+    {
+        var tv = Traverse.Create(process);
+        var ctn = tv.Field("container").GetValue<ProcessDataContainer>();
+        ctn.processManager.AddProcess((ProcessBase) new ErrorProcess(ctn));
+        ctn.processManager.ReleaseProcess(process);
+        GameManager.IsErrorMode = true;
+    }
+    
+    // patch the error monitor so that it can display custom error codes and messages.
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(ErrorMonitor), "Initialize", typeof(int), typeof(bool))]
+    public static void PostInitialize(ErrorMonitor __instance)
+    {
+        var tv = Traverse.Create(__instance);
+        if (_customErrCode == 0)
+        {
+            MelonLogger.Msg($"Displaying error frame with AMDaemon code {AMDaemon.Error.Number}: {AMDaemon.Error.Message}");
+            return;
+        }
+        MelonLogger.Msg($"Displaying error frame with custom code {_customErrCode}: {_customErrMsg}");
+        tv.Field("ErrorID").GetValue<TextMeshProUGUI>().text = _customErrCode.ToString().PadLeft(4, '0');
+        tv.Field("ErrorMessage").GetValue<TextMeshProUGUI>().text = _customErrMsg;
+        tv.Field("ErrorDate").GetValue<TextMeshProUGUI>().text = _customErrDate.ToString();
+    }
+    
+}

--- a/AquaMai.Core/Startup.cs
+++ b/AquaMai.Core/Startup.cs
@@ -164,6 +164,7 @@ public class Startup
         CollectWantedPatches(wantedPatches, typeof(KeyListener));
         CollectWantedPatches(wantedPatches, typeof(Shim));
         CollectWantedPatches(wantedPatches, typeof(NetPacketHook));
+        CollectWantedPatches(wantedPatches, typeof(ErrorFrame));
         // 使用时才 patch！不要添加这个
         // CollectWantedPatches(wantedPatches, typeof(GameSettingsManager));
 

--- a/AquaMai.Mods/UX/HardwareAlert.cs
+++ b/AquaMai.Mods/UX/HardwareAlert.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics;
+using AquaMai.Config.Attributes;
+using AquaMai.Core.Resources;
+using HarmonyLib;
+using IO;
+using MAI2.Util;
+using Main;
+using Manager;
+using Process;
+using Process.Error;
+using UnityEngine;
+
+namespace AquaMai.Mods.UX;
+
+[ConfigSection(
+    defaultOn: true,
+    zh: "自定义硬件警告，可配置在指定硬件自检失败时阻止游戏启动并显示报错画面")]
+public class HardwareAlert : MonoBehaviour
+{
+    private static HardwareAlert display;
+    private Stopwatch stopwatch = new Stopwatch();
+
+    // [HarmonyPostfix]
+    // [HarmonyPatch(typeof(StartupProcess), "OnUpdate")]
+    // public static void OnPostUpdate(StartupProcess __instance)
+    // {
+    //     var tv = Traverse.Create(__instance);
+    //     if (tv.Field("_state").GetValue<byte>() > 0)
+    //     {
+    //         if (SingletonStateMachine<AmManager, AmManager.EState>.Instance.NewTouchPanel[1].Status ==
+    //             NewTouchPanel.StatusEnum.Error)
+    //         {
+    //             var go = new GameObject("硬件提示组件");
+    //             display = go.AddComponent<HardwareAlert>();
+    //         }
+    //     }
+    // }
+
+    private static int errorCode;
+    private static string errorMessage;
+    
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(StartupProcess), "OnUpdate")]
+    public static void OnPostUpdate(StartupProcess __instance)
+    {
+        if (AMDaemon.Error.Number > 0)
+        {
+            var tv = Traverse.Create(__instance);
+            var ctn = tv.Field("container").GetValue<ProcessDataContainer>();
+            ctn.processManager.AddProcess((ProcessBase) new ErrorProcess(ctn));
+            ctn.processManager.ReleaseProcess((ProcessBase) __instance);
+            GameManager.IsErrorMode = true;
+            // errorCode = AMDaemon.Error.Number;
+            // errorMessage = AMDaemon.Error.Message;
+            // var go = new GameObject("硬件提示组件");
+            // display = go.AddComponent<HardwareAlert>();
+        }
+    }
+
+    private void Start()
+    {
+        stopwatch.Start();
+    }
+
+    private void OnGUI()
+    {
+        if (stopwatch.ElapsedMilliseconds < 2000)
+        {
+            return;
+        }
+        GUIStyle styleTitle = new GUIStyle(GUI.skin.label)
+        {
+            fontSize = 35,
+            alignment = TextAnchor.MiddleCenter,
+            wordWrap = true
+        };
+        GUIStyle style = new GUIStyle(GUI.skin.label)
+        {
+            fontSize = 25,
+            alignment = TextAnchor.MiddleLeft,
+            wordWrap = true
+        };
+
+        GUI.Label(new Rect(50, 50, Screen.width - 50, Screen.height - 500), "AMDaemon Error", styleTitle);
+        GUI.Label(new Rect(50, 50, Screen.width - 50, Screen.height - 50), $"出现错误：{errorCode}, Message: {errorMessage}", style);
+    }
+}

--- a/AquaMai.Mods/UX/HardwareAlert.cs
+++ b/AquaMai.Mods/UX/HardwareAlert.cs
@@ -65,6 +65,7 @@ public class HardwareAlert
 
     private static readonly List<string> CameraTypeList = ["QRLeft", "QRRight", "Photo", "Chime"];
     private static SortedDictionary<CameraTypeEnumInner, int> _cameraIndex = [];
+    private static bool _isInitialized = false;
 
     private enum CameraTypeEnumInner
     {
@@ -78,6 +79,11 @@ public class HardwareAlert
     [HarmonyPatch(typeof(CameraManager), "CameraInitialize")]
     public static void PostCameraInitialize(CameraManager __instance)
     {
+        if (_isInitialized)
+        {
+            return;
+        }
+        
         var curCamIdx = 0;
         foreach (var cameraTypeName in CameraTypeList)
         {
@@ -85,8 +91,11 @@ public class HardwareAlert
             {
                 MelonLogger.Msg($"[HardwareAlert] Identified camera type {cameraType} for current game version on idx {curCamIdx}");
                 _cameraIndex[cameraType] = curCamIdx;
+                curCamIdx++;
             }
         }
+
+        _isInitialized = true;
     }
     
     [HarmonyPostfix]

--- a/AquaMai.Mods/UX/HardwareAlert.cs
+++ b/AquaMai.Mods/UX/HardwareAlert.cs
@@ -22,6 +22,7 @@ using UnityEngine;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
+    en: "Custom hardware alert, you can configure to display an error frame upon hardware failure. Toggle the switches below to define the required hardware.",
     zh: "自定义硬件警告，可配置在指定硬件自检失败时阻止游戏启动并显示报错画面，开启下方的错误类型以配置需要关注的错误。")]
 public class HardwareAlert
 {

--- a/AquaMai.Mods/UX/HardwareAlert.cs
+++ b/AquaMai.Mods/UX/HardwareAlert.cs
@@ -100,7 +100,7 @@ public class HardwareAlert
                 TouchSensor_2P && (AMDaemon.Error.Number == 3302 || AMDaemon.Error.Number == 3303)
                 )
             {
-                ShowErrorFrame(__instance);
+                ErrorFrame.Show(__instance);
                 return;
             }
         }
@@ -113,24 +113,24 @@ public class HardwareAlert
         // Do another version check, since the AMDaemon error code gets disappeared sometimes...
         if (TouchSensor_1P && statusSubMsg[0] == ConstParameter.TestString_Bad)
         {
-            ShowErrorFrame(__instance, 3300, FaultTouchSensor1P[GetLocale()]);
+            ErrorFrame.Show(__instance, 3300, FaultTouchSensor1P[GetLocale()]);
             return;
         }
         if (TouchSensor_2P && statusSubMsg[1] == ConstParameter.TestString_Bad)
         {
-            ShowErrorFrame(__instance, 3302, FaultTouchSensor2P[GetLocale()]);
+            ErrorFrame.Show(__instance, 3302, FaultTouchSensor2P[GetLocale()]);
             return;
         }
 
         // LED check
         if (LED_1P && statusSubMsg[2] == ConstParameter.TestString_Bad)
         {
-            ShowErrorFrame(__instance, 3400, FaultLED1P[GetLocale()]);
+            ErrorFrame.Show(__instance, 3400, FaultLED1P[GetLocale()]);
             return;
         }
         if (LED_2P && statusSubMsg[3] == ConstParameter.TestString_Bad)
         {
-            ShowErrorFrame(__instance, 3401, FaultLED2P[GetLocale()]);
+            ErrorFrame.Show(__instance, 3401, FaultLED2P[GetLocale()]);
             return;
         }
         
@@ -139,58 +139,25 @@ public class HardwareAlert
         {
             if (PlayerCamera && !CameraManager.IsAvailableCameras[_cameraIndex[CameraTypeEnumInner.Photo]])
             {
-                ShowErrorFrame(__instance, 3102, FaultPlayerCamera[GetLocale()]);
+                ErrorFrame.Show(__instance, 3102, FaultPlayerCamera[GetLocale()]);
                 return;
             }
             if (CodeReader_1P && !CameraManager.IsAvailableCameras[_cameraIndex[CameraTypeEnumInner.QRLeft]])
             {
-                ShowErrorFrame(__instance, 3101, FaultQR1P[GetLocale()]);
+                ErrorFrame.Show(__instance, 3101, FaultQR1P[GetLocale()]);
                 return;
             }
             if (CodeReader_2P && !CameraManager.IsAvailableCameras[_cameraIndex[CameraTypeEnumInner.QRRight]])
             {
-                ShowErrorFrame(__instance, 3101, FaultQR2P[GetLocale()]);
+                ErrorFrame.Show(__instance, 3101, FaultQR2P[GetLocale()]);
                 return;
             }
             if (ChimeCamera && !CameraManager.IsAvailableCameras[_cameraIndex[CameraTypeEnumInner.Chime]])
             {
-                ShowErrorFrame(__instance, 3100, FaultChime[GetLocale()]);
+                ErrorFrame.Show(__instance, 3100, FaultChime[GetLocale()]);
                 return;
             }
         }
-    }
-
-    private static void ShowErrorFrame(ProcessBase process)
-    {
-        var tv = Traverse.Create(process);
-        var ctn = tv.Field("container").GetValue<ProcessDataContainer>();
-        ctn.processManager.AddProcess((ProcessBase) new ErrorProcess(ctn));
-        ctn.processManager.ReleaseProcess(process);
-        GameManager.IsErrorMode = true;
-    }
-
-    private static int customErrCode;
-    private static string customErrMsg;
-    private static DateTime customErrDate;
-    
-    // patch the error monitor so that it can display custom error codes and messages.
-    [HarmonyPostfix]
-    [HarmonyPatch(typeof(ErrorMonitor), "Initialize", typeof(int), typeof(bool))]
-    public static void PostInitialize(ErrorMonitor __instance)
-    {
-        var tv = Traverse.Create(__instance);
-        if (customErrCode == 0) return;
-        tv.Field("ErrorID").GetValue<TextMeshProUGUI>().text = customErrCode.ToString().PadLeft(4, '0');
-        tv.Field("ErrorMessage").GetValue<TextMeshProUGUI>().text = customErrMsg;
-        tv.Field("ErrorDate").GetValue<TextMeshProUGUI>().text = customErrDate.ToString();
-    }
-    
-    private static void ShowErrorFrame(ProcessBase process, int errCode, string errMsg)
-    {
-        customErrCode = errCode;
-        customErrMsg = errMsg;
-        customErrDate = DateTime.Now;
-        ShowErrorFrame(process);
     }
 
     private static string GetLocale()

--- a/AquaMai.Mods/UX/HardwareAlert.cs
+++ b/AquaMai.Mods/UX/HardwareAlert.cs
@@ -92,25 +92,14 @@ public class HardwareAlert
     [HarmonyPatch(typeof(StartupProcess), "OnUpdate")]
     public static void OnPostUpdate(StartupProcess __instance)
     {
-        if (AMDaemon.Error.Number > 0)
-        {
-            // if we have official AMDaemon error for sensors, just use them.
-            if (
-                TouchSensor_1P && (AMDaemon.Error.Number == 3300 || AMDaemon.Error.Number == 3301) ||
-                TouchSensor_2P && (AMDaemon.Error.Number == 3302 || AMDaemon.Error.Number == 3303)
-                )
-            {
-                ErrorFrame.Show(__instance);
-                return;
-            }
-        }
-        
         // get current startup state
         var tv = Traverse.Create(__instance);
         // var state = tv.Field("_state").GetValue<byte>();
         var statusSubMsg = tv.Field("_statusSubMsg").GetValue<string[]>();
         
-        // Do another version check, since the AMDaemon error code gets disappeared sometimes...
+        // Touch sensor check
+        // The built-in AMDaemon errors are not stable, and cannot be localized.
+        // So we decided to use another approach to check it.
         if (TouchSensor_1P && statusSubMsg[0] == ConstParameter.TestString_Bad)
         {
             ErrorFrame.Show(__instance, 3300, FaultTouchSensor1P[GetLocale()]);
@@ -137,22 +126,31 @@ public class HardwareAlert
         // Camera Check
         if (CameraManager.IsReady)
         {
-            if (PlayerCamera && !CameraManager.IsAvailableCameras[_cameraIndex[CameraTypeEnumInner.Photo]])
+            var nCam = CameraManager.IsAvailableCameras.Length;
+
+            var pcIdx = _cameraIndex[CameraTypeEnumInner.Photo];
+            if (PlayerCamera && pcIdx < nCam && !CameraManager.IsAvailableCameras[pcIdx])
             {
                 ErrorFrame.Show(__instance, 3102, FaultPlayerCamera[GetLocale()]);
                 return;
             }
-            if (CodeReader_1P && !CameraManager.IsAvailableCameras[_cameraIndex[CameraTypeEnumInner.QRLeft]])
+
+            var cr1PIdx = _cameraIndex[CameraTypeEnumInner.QRLeft];
+            if (CodeReader_1P && cr1PIdx < nCam && !CameraManager.IsAvailableCameras[cr1PIdx])
             {
                 ErrorFrame.Show(__instance, 3101, FaultQR1P[GetLocale()]);
                 return;
             }
-            if (CodeReader_2P && !CameraManager.IsAvailableCameras[_cameraIndex[CameraTypeEnumInner.QRRight]])
+
+            var cr2PIdx = _cameraIndex[CameraTypeEnumInner.QRRight];
+            if (CodeReader_2P && cr2PIdx < nCam && !CameraManager.IsAvailableCameras[cr2PIdx])
             {
                 ErrorFrame.Show(__instance, 3101, FaultQR2P[GetLocale()]);
                 return;
             }
-            if (ChimeCamera && !CameraManager.IsAvailableCameras[_cameraIndex[CameraTypeEnumInner.Chime]])
+
+            var chimeIdx = _cameraIndex[CameraTypeEnumInner.Chime];
+            if (ChimeCamera && chimeIdx < nCam && !CameraManager.IsAvailableCameras[chimeIdx])
             {
                 ErrorFrame.Show(__instance, 3100, FaultChime[GetLocale()]);
                 return;

--- a/AquaMai.Mods/UX/HardwareAlert.cs
+++ b/AquaMai.Mods/UX/HardwareAlert.cs
@@ -94,6 +94,7 @@ public class HardwareAlert
     {
         if (AMDaemon.Error.Number > 0)
         {
+            // if we have official AMDaemon error for sensors, just use them.
             if (
                 TouchSensor_1P && (AMDaemon.Error.Number == 3300 || AMDaemon.Error.Number == 3301) ||
                 TouchSensor_2P && (AMDaemon.Error.Number == 3302 || AMDaemon.Error.Number == 3303)
@@ -106,8 +107,20 @@ public class HardwareAlert
         
         // get current startup state
         var tv = Traverse.Create(__instance);
-        var state = tv.Field("_state").GetValue<byte>();
+        // var state = tv.Field("_state").GetValue<byte>();
         var statusSubMsg = tv.Field("_statusSubMsg").GetValue<string[]>();
+        
+        // Do another version check, since the AMDaemon error code gets disappeared sometimes...
+        if (TouchSensor_1P && statusSubMsg[0] == ConstParameter.TestString_Bad)
+        {
+            ShowErrorFrame(__instance, 3300, FaultTouchSensor1P[GetLocale()]);
+            return;
+        }
+        if (TouchSensor_2P && statusSubMsg[1] == ConstParameter.TestString_Bad)
+        {
+            ShowErrorFrame(__instance, 3302, FaultTouchSensor2P[GetLocale()]);
+            return;
+        }
 
         // LED check
         if (LED_1P && statusSubMsg[2] == ConstParameter.TestString_Bad)
@@ -199,6 +212,18 @@ public class HardwareAlert
         ["SDEZ"] = "jp",
         ["SDGA"] = "en",
         ["SDGB"] = "zh",
+    };
+    private static readonly Dictionary<string, string> FaultTouchSensor1P = new()
+    {
+        ["jp"] = "タッチセンサ（1P）はご利用いただけません",
+        ["en"] = "Touch Sensor (1P) not available",
+        ["zh"] = "触摸传感器（1P）不可用",
+    };
+    private static readonly Dictionary<string, string> FaultTouchSensor2P = new()
+    {
+        ["jp"] = "タッチセンサ（2P）はご利用いただけません",
+        ["en"] = "Touch Sensor (2P) not available",
+        ["zh"] = "触摸传感器（2P）不可用",
     };
     private static readonly Dictionary<string, string> FaultLED1P = new()
     {

--- a/AquaMai/configSort.yaml
+++ b/AquaMai/configSort.yaml
@@ -75,6 +75,7 @@
   - Utils.LogNetworkRequests
   - Utils.ShowErrorLog
   - UX.NoAmDaemonAlert
+  - UX.HardwareAlert
 
 键位和灵敏度:
   - GameSystem.HidInput


### PR DESCRIPTION
### Before

Currently, when any hardware is unavailable, the system only displays a "BAD" status in the list, and the message quickly disappears.

### After (with this MR)

This merge request introduces a custom hardware check that halts the startup process if a hardware error is detected.
_**Users can configure which hardware components should be monitored**_, ensuring the system does not proceed until the specified devices are available and functioning correctly.

Additionally, the ErrorFrame implementation adopts the built-in startup error window style of the system, closely replicating the way arcade machines display errors during the boot process.

<img width="1708" height="675" alt="image" src="https://github.com/user-attachments/assets/f06332be-0a62-4d07-8c96-9fde21530439" />

## Sourcery 总结

引入一个 `HardwareAlert` 模块和辅助的 `ErrorFrame` 助手，用于在启动时监控指定的硬件组件，在出现故障时阻止初始化，并显示一个带有自定义代码和消息的样式化错误窗口。

新功能：
- 添加可配置的硬件检查，在组件缺失或故障时中止启动
- 在硬件故障时，显示带有自定义代码和消息的详细街机风格错误帧

改进：
- 在启动补丁管道中注册 `ErrorFrame`，并与 `ErrorMonitor` 集成以覆盖错误显示
- 修补 `CameraManager` 以动态检测和索引摄像头类型进行监控

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a HardwareAlert module and supporting ErrorFrame helper to monitor specified hardware components during startup, block initialization on failures, and present a styled error window with custom codes and messages.

New Features:
- Add configurable hardware checks that halt startup on missing or failing components
- Display detailed arcade-style error frames with custom codes and messages on hardware faults

Enhancements:
- Register ErrorFrame in the startup patch pipeline and integrate with ErrorMonitor to override error display
- Patch CameraManager to dynamically detect and index camera types for monitoring

</details>