### PR TITLE
feat: Add configurable Answer Sound offset and player menu toggle

### DIFF
--- a/AquaMai.Mods/Utils/MoveAnswerSound.cs
+++ b/AquaMai.Mods/Utils/MoveAnswerSound.cs
@@ -31,12 +31,12 @@ public class MoveAnswerSound : IPlayerSettingsItem
     [ConfigEntry(
         en: "Answer sound move value in ms, this value will be combined with user's setting in game. Increase this value to make the answer sound appear later, vice versa.",
         zh: "正解音偏移量，单位为毫秒，此设定值会与用户游戏内的设置相加。增大这个值将会使正解音出现得更晚，反之则更早。")]
-    private static readonly float MoveValue_1P = 33f;
+    private static readonly float MoveValue_1P = 0f;
     
     [ConfigEntry(
         en: "Same as MoveValue_1P.",
         zh: "与 MoveValue_1P 作用相同。")]
-    private static readonly float MoveValue_2P = 33f;
+    private static readonly float MoveValue_2P = 0f;
     
     private static float[] userSettings = [0, 0];
     private static IPersistentStorage storage = new PlayerPrefsStorage();
@@ -137,12 +137,12 @@ public class MoveAnswerSound : IPlayerSettingsItem
                 continue;
             }
             if (note.type.isSlide() || note.type.isConnectSlide()) continue;
-            if (NotesManager.GetCurrentMsec() - GetSettingsValue(__instance.MonitorIndex) > note.time.msec && !note.playAnsSoundHead)
+            if (NotesManager.GetCurrentMsec() - 33f - GetSettingsValue(__instance.MonitorIndex) > note.time.msec && !note.playAnsSoundHead)
             {
                 Singleton<GameSingleCueCtrl>.Instance.ReserveAnswerSe(__instance.MonitorIndex);
                 note.playAnsSoundHead = true;
             }
-            if (note.type.isHold() && NotesManager.GetCurrentMsec() - GetSettingsValue(__instance.MonitorIndex) > note.end.msec && !note.playAnsSoundTail)
+            if (note.type.isHold() && NotesManager.GetCurrentMsec() - 33f - GetSettingsValue(__instance.MonitorIndex) > note.end.msec && !note.playAnsSoundTail)
             {
                 Singleton<GameSingleCueCtrl>.Instance.ReserveAnswerSe(__instance.MonitorIndex);
                 note.playAnsSoundTail = true;

--- a/AquaMai.Mods/Utils/MoveAnswerSound.cs
+++ b/AquaMai.Mods/Utils/MoveAnswerSound.cs
@@ -20,17 +20,33 @@ namespace AquaMai.Mods.Utils;
 
 [ConfigSection(
     en: "Move answer sound",
-    zh: "移动正解音。此设置提供分用户设置，请在游戏内设置中调整偏移量")]
+    zh: "移动正解音")]
 public class MoveAnswerSound : IPlayerSettingsItem
 {
+    [ConfigEntry(
+        en: "Display in-game config entry for player.",
+        zh: "在游戏内添加设置项给用户，使用户能够在游戏内调整正解音偏移量。")]
+    private static readonly bool DisplayInGameConfig = true;
+    
+    [ConfigEntry(
+        en: "Answer sound move value in ms, this value will be combined with user's setting in game. Increase this value to make the answer sound appear later, vice versa.",
+        zh: "正解音偏移量，单位为毫秒，此设定值会与用户游戏内的设置相加。增大这个值将会使正解音出现得更晚，反之则更早。")]
+    private static readonly float MoveValue = 33f;
+    
     private static float[] userSettings = [0, 0];
     private static IPersistentStorage storage = new PlayerPrefsStorage();
+
+    private static float GetSettingsValue(uint monitorIndex) => userSettings[monitorIndex] + MoveValue;
+    private static float GetSettingsValue(int monitorIndex) => GetSettingsValue((uint)monitorIndex);
 
     #region 设置界面注入
 
     public static void OnBeforePatch()
     {
-        GameSettingsManager.RegisterSetting(new MoveAnswerSound());
+        if (DisplayInGameConfig)
+        {
+            GameSettingsManager.RegisterSetting(new MoveAnswerSound());
+        }
     }
 
     public int Sort => 50;
@@ -67,7 +83,7 @@ public class MoveAnswerSound : IPlayerSettingsItem
             var userData = UserDataManager.Instance.GetUserData(i);
             if (!userData.IsEntry) continue;
             userSettings[i] = storage.GetFloat(i, "MoveAnswerSound", 0);
-            MelonLogger.Msg($"玩家 {i} 的移动正解音设置为 {userSettings[i]} 毫秒");
+            MelonLogger.Msg($"玩家 {i} 的移动正解音设置为 {GetSettingsValue(i)} 毫秒，其中游戏内设置为 {userSettings[i]} 毫秒，机台设置为 {MoveValue} 毫秒");
         }
     }
 
@@ -103,12 +119,12 @@ public class MoveAnswerSound : IPlayerSettingsItem
                 continue;
             }
             if (note.type.isSlide() || note.type.isConnectSlide()) continue;
-            if (NotesManager.GetCurrentMsec() - 33f - userSettings[__instance.MonitorIndex] > note.time.msec && !note.playAnsSoundHead)
+            if (NotesManager.GetCurrentMsec() - GetSettingsValue(__instance.MonitorIndex) > note.time.msec && !note.playAnsSoundHead)
             {
                 Singleton<GameSingleCueCtrl>.Instance.ReserveAnswerSe(__instance.MonitorIndex);
                 note.playAnsSoundHead = true;
             }
-            if (note.type.isHold() && NotesManager.GetCurrentMsec() - 33f - userSettings[__instance.MonitorIndex] > note.end.msec && !note.playAnsSoundTail)
+            if (note.type.isHold() && NotesManager.GetCurrentMsec() - GetSettingsValue(__instance.MonitorIndex) > note.end.msec && !note.playAnsSoundTail)
             {
                 Singleton<GameSingleCueCtrl>.Instance.ReserveAnswerSe(__instance.MonitorIndex);
                 note.playAnsSoundTail = true;

--- a/AquaMai.Mods/Utils/MoveAnswerSound.cs
+++ b/AquaMai.Mods/Utils/MoveAnswerSound.cs
@@ -31,12 +31,23 @@ public class MoveAnswerSound : IPlayerSettingsItem
     [ConfigEntry(
         en: "Answer sound move value in ms, this value will be combined with user's setting in game. Increase this value to make the answer sound appear later, vice versa.",
         zh: "正解音偏移量，单位为毫秒，此设定值会与用户游戏内的设置相加。增大这个值将会使正解音出现得更晚，反之则更早。")]
-    private static readonly float MoveValue = 33f;
+    private static readonly float MoveValue1P = 33f;
+    
+    [ConfigEntry(
+        en: "Same as MoveValue1P.",
+        zh: "与 MoveValue1P 作用相同.")]
+    private static readonly float MoveValue2P = 33f;
     
     private static float[] userSettings = [0, 0];
     private static IPersistentStorage storage = new PlayerPrefsStorage();
 
-    private static float GetSettingsValue(uint monitorIndex) => DisplayInGameConfig ? userSettings[monitorIndex] + MoveValue : MoveValue;
+    private static float GetCabinSettingsValue(uint monitorIndex) => monitorIndex == 0 ? MoveValue1P : MoveValue2P;
+    private static float GetSettingsValue(uint monitorIndex)
+    {
+        var moveValue = GetCabinSettingsValue(monitorIndex);
+        return DisplayInGameConfig ? userSettings[monitorIndex] + moveValue : moveValue;
+    }
+    
     private static float GetSettingsValue(int monitorIndex) => GetSettingsValue((uint)monitorIndex);
 
     #region 设置界面注入
@@ -85,11 +96,11 @@ public class MoveAnswerSound : IPlayerSettingsItem
             userSettings[i] = storage.GetFloat(i, "MoveAnswerSound", 0);
             if (DisplayInGameConfig)
             {
-                MelonLogger.Msg($"玩家 {i} 的移动正解音设置为 {GetSettingsValue(i)} 毫秒，其中游戏内设置为 {userSettings[i]} 毫秒，机台设置为 {MoveValue} 毫秒");
+                MelonLogger.Msg($"玩家 {i} 的移动正解音设置为 {GetSettingsValue(i)} 毫秒，其中游戏内设置为 {userSettings[i]} 毫秒，机台设置为 {GetCabinSettingsValue(i)} 毫秒");
             }
             else
             {
-                MelonLogger.Msg($"玩家 {i} 的移动正解音设置为 {GetSettingsValue(i)} 毫秒，其中游戏内设置已被禁用，机台设置为 {MoveValue} 毫秒");
+                MelonLogger.Msg($"玩家 {i} 的移动正解音设置为 {GetSettingsValue(i)} 毫秒，其中游戏内设置已被禁用，机台设置为 {GetCabinSettingsValue(i)} 毫秒");
             }
         }
     }

--- a/AquaMai.Mods/Utils/MoveAnswerSound.cs
+++ b/AquaMai.Mods/Utils/MoveAnswerSound.cs
@@ -31,17 +31,17 @@ public class MoveAnswerSound : IPlayerSettingsItem
     [ConfigEntry(
         en: "Answer sound move value in ms, this value will be combined with user's setting in game. Increase this value to make the answer sound appear later, vice versa.",
         zh: "正解音偏移量，单位为毫秒，此设定值会与用户游戏内的设置相加。增大这个值将会使正解音出现得更晚，反之则更早。")]
-    private static readonly float MoveValue1P = 33f;
+    private static readonly float MoveValue_1P = 33f;
     
     [ConfigEntry(
-        en: "Same as MoveValue1P.",
-        zh: "与 MoveValue1P 作用相同.")]
-    private static readonly float MoveValue2P = 33f;
+        en: "Same as MoveValue_1P.",
+        zh: "与 MoveValue_1P 作用相同。")]
+    private static readonly float MoveValue_2P = 33f;
     
     private static float[] userSettings = [0, 0];
     private static IPersistentStorage storage = new PlayerPrefsStorage();
 
-    private static float GetCabinSettingsValue(uint monitorIndex) => monitorIndex == 0 ? MoveValue1P : MoveValue2P;
+    private static float GetCabinSettingsValue(uint monitorIndex) => monitorIndex == 0 ? MoveValue_1P : MoveValue_2P;
     private static float GetSettingsValue(uint monitorIndex)
     {
         var moveValue = GetCabinSettingsValue(monitorIndex);

--- a/AquaMai.Mods/Utils/MoveAnswerSound.cs
+++ b/AquaMai.Mods/Utils/MoveAnswerSound.cs
@@ -83,7 +83,14 @@ public class MoveAnswerSound : IPlayerSettingsItem
             var userData = UserDataManager.Instance.GetUserData(i);
             if (!userData.IsEntry) continue;
             userSettings[i] = storage.GetFloat(i, "MoveAnswerSound", 0);
-            MelonLogger.Msg($"玩家 {i} 的移动正解音设置为 {GetSettingsValue(i)} 毫秒，其中游戏内设置为 {userSettings[i]} 毫秒，机台设置为 {MoveValue} 毫秒");
+            if (DisplayInGameConfig)
+            {
+                MelonLogger.Msg($"玩家 {i} 的移动正解音设置为 {GetSettingsValue(i)} 毫秒，其中游戏内设置为 {userSettings[i]} 毫秒，机台设置为 {MoveValue} 毫秒");
+            }
+            else
+            {
+                MelonLogger.Msg($"玩家 {i} 的移动正解音设置为 {GetSettingsValue(i)} 毫秒，其中游戏内设置已被禁用，机台设置为 {MoveValue} 毫秒");
+            }
         }
     }
 

--- a/AquaMai.Mods/Utils/MoveAnswerSound.cs
+++ b/AquaMai.Mods/Utils/MoveAnswerSound.cs
@@ -24,8 +24,8 @@ namespace AquaMai.Mods.Utils;
 public class MoveAnswerSound : IPlayerSettingsItem
 {
     [ConfigEntry(
-        en: "Display in-game config entry for player.",
-        zh: "在游戏内添加设置项给用户，使用户能够在游戏内调整正解音偏移量。")]
+        en: "Display in-game config entry for player. If disabled, the user's settings will be ignored.",
+        zh: "在游戏内添加设置项给用户，使用户能够在游戏内调整正解音偏移量。如果关闭此选项，则就算用户之前设置过，也会忽略。")]
     private static readonly bool DisplayInGameConfig = true;
     
     [ConfigEntry(
@@ -36,7 +36,7 @@ public class MoveAnswerSound : IPlayerSettingsItem
     private static float[] userSettings = [0, 0];
     private static IPersistentStorage storage = new PlayerPrefsStorage();
 
-    private static float GetSettingsValue(uint monitorIndex) => userSettings[monitorIndex] + MoveValue;
+    private static float GetSettingsValue(uint monitorIndex) => DisplayInGameConfig ? userSettings[monitorIndex] + MoveValue : MoveValue;
     private static float GetSettingsValue(int monitorIndex) => GetSettingsValue((uint)monitorIndex);
 
     #region 设置界面注入


### PR DESCRIPTION
### Background

Previously, the Answer Sound offset adjustment could only be performed in-game by players. However, since answer offset issues are often a machine-wide problem rather than a player-specific one, this approach was inconvenient and repetitive.

### Changes

New configuration option:
Added a global answer sound offset setting in the configuration file, allowing machine owners to directly adjust the Answer Sound offset for the entire machine.

Menu toggle:
Introduced a switch for the in-game configuration menu that lets the machine owner decide whether players are allowed to access and change the offset setting during gameplay.

```
## 由 Sourcery 总结

引入了一个全局答题音效偏移配置，支持可选的游戏内调整，并更新了计时逻辑以结合机器范围和用户特定的设置。

新功能：
- 在配置文件中为 1P 和 2P 添加全局答题音效偏移设置
- 引入一个 DisplayInGameConfig 开关，以启用或禁用游戏内偏移调整入口

改进：
- 重构音效计时计算，以结合全局机器偏移和用户特定偏移
- 根据新开关条件性地注册游戏内设置入口
- 改进日志记录，以报告有效偏移及其来源
```

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a global answer sound offset configuration with optional in-game adjustment and update the timing logic to combine machine-wide and per-user settings.

New Features:
- Add global answer sound offset settings for 1P and 2P in the configuration file
- Introduce a DisplayInGameConfig toggle to enable or disable the in-game offset adjustment entry

Enhancements:
- Refactor sound timing calculations to combine global machine offset with user-specific offset
- Conditionally register the in-game settings entry based on the new toggle
- Improve logging to report both the effective offset and its sources

</details>