### PR TITLE
[+] ReviveFinaleVSlide

### DIFF
--- a/AquaMai.Mods/GameSystem/ReviveFinaleVSlide.cs
+++ b/AquaMai.Mods/GameSystem/ReviveFinaleVSlide.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using System.Reflection.Emit;
+using AquaMai.Core.Attributes;
+using AquaMai.Config.Attributes;
+using HarmonyLib;
+using Manager;
+using MelonLoader;
+
+namespace AquaMai.Mods.GameSystem;
+
+[ConfigSection(
+    en: "Allow v-shaped slide with the same starting and ending point, such as \"1v1\" in Simai notation",
+    zh: "允许形如 \"1v1\" 的，起点和终点相同的 v 型星星")]
+public static class ReviveFinaleVSlide
+{
+    public static List<string> InsertData(List<string> list)
+    {
+        MelonLogger.Msg("[ReviveFinaleVSlide] Insert SVG data");
+        
+        list[0] = "V_1.svg";
+        return list;
+    }
+    
+    public static List<List<SlideManager.HitArea>> InsertHitArea(List<List<SlideManager.HitArea>> list)
+    {
+        MelonLogger.Msg("[ReviveFinaleVSlide] Insert hit area list");;
+        
+        list[0] = [ 
+            new SlideManager.HitArea
+            {
+                HitPoints = [InputManager.TouchPanelArea.A1],
+                PushDistance = 156.42124938964844,
+                ReleaseDistance = 43.27423858642578
+            },
+            new SlideManager.HitArea
+            {
+                HitPoints = [InputManager.TouchPanelArea.B1],
+                PushDistance = 128.9917755126953,
+                ReleaseDistance = 42.19921875
+            },
+            new SlideManager.HitArea
+            {
+                HitPoints = [InputManager.TouchPanelArea.C1],
+                PushDistance = 218.6302947998047,
+                ReleaseDistance = 42.19921875
+            },
+            new SlideManager.HitArea
+            {
+                HitPoints = [InputManager.TouchPanelArea.B1],
+                PushDistance = 128.9917755126953,
+                ReleaseDistance = 43.27423858642578
+            },
+            new SlideManager.HitArea
+            {
+                HitPoints = [InputManager.TouchPanelArea.A1],
+                PushDistance = 156.42124938964844,
+                ReleaseDistance = 0.0
+            }
+        ];
+        return list;
+    }
+
+    [HarmonyPatch(typeof(SlideManager), MethodType.Constructor)]
+    public static class SlideDataPatch
+    {
+        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            var vDataList = AccessTools.Field(typeof(SlideManager), "_vDataList");
+            var vHitAreaList = AccessTools.Field(typeof(SlideManager), "_vHitAreaList");
+
+            foreach (var insn in instructions)
+            {
+                if (insn.StoresField(vDataList))
+                {
+                    yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(ReviveFinaleVSlide), "InsertData"));
+                }
+                else if (insn.StoresField(vHitAreaList))
+                {
+                    yield return new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(ReviveFinaleVSlide), "InsertHitArea"));
+                }
+
+                yield return insn;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Allow v-shaped slide with the same starting and ending point, such as `1v1` in Simai notation.

## Sourcery 总结

通过使用 Harmony 转译器在运行时修补游戏的滑条数据和判定区域列表，启用同点V形滑条，并为该功能公开一个本地化的配置选项。

新功能：
- 支持起点和终点相同的V形滑条（例如，Simai 记谱中的 "1v1"）

改进：
- 通过 Harmony 转译器将自定义 SVG 数据和判定区域配置注入到 SlideManager 初始化中
- 添加一个本地化配置部分，用于切换 ReviveFinaleVSlide 功能

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable same-point v-shaped slides by patching the games slide data and hit area lists at runtime using a Harmony transpiler and expose a localized config option for the feature.

New Features:
- Support v-shaped slides where the starting and ending points are identical (e.g., "1v1" in Simai notation)

Enhancements:
- Inject custom SVG data and hit area configurations into SlideManager initialization via a Harmony transpiler
- Add a localized configuration section for toggling the ReviveFinaleVSlide feature

</details>