### PR TITLE
fix: DisplayTouchInGame 在maimoller中不工作

### DIFF
--- a/AquaMai.Mods/Utils/DisplayTouchInGame.cs
+++ b/AquaMai.Mods/Utils/DisplayTouchInGame.cs
@@ -201,4 +201,13 @@ public static class DisplayTouchInGame
             }
         }
     }
+    
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(MouseTouchPanel), "Start")]
+    public static void Workaround() { }
+    /*
+     * 和 https://github.com/MewoLab/AquaMai/blob/983f887be48d6c5c85a81460fa3c45d2d35c3852/AquaMai.Mods/GameSystem/TestProof.cs#L78-L87 的情况是一样的...
+     * 在Maimoller的Mod Patch之后，MouseTouchPanel.Start就不会被调用了，但是放一个钩子在它身上，就一切正常了...
+     * 我没有能力研究的特别透彻，就先和上面采取一样的做法了...留给后来者研究吧
+     */
 }


### PR DESCRIPTION
其实和这个是一模一样的情况...
https://github.com/MewoLab/AquaMai/blob/983f887be48d6c5c85a81460fa3c45d2d35c3852/AquaMai.Mods/GameSystem/TestProof.cs#L78-L87

MouseTouchPanel.Start不会调用，自然依赖于其的RegisterMouseTouchPanel钩子也不会调用，prefab就为null，导致log里报错`[DisplayTouchInGame] prefab is null`

实在是太玄学了......

## Sourcery 总结

Bug 修复:
- 绕过 MaiMoller mod 阻止 MouseTouchPanel.Start 被调用的问题，通过注入一个空的 HarmonyPostfix，从而允许 DisplayTouchInGame 正确初始化

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Work around MaiMoller mod preventing MouseTouchPanel.Start from being called by injecting an empty HarmonyPostfix, allowing DisplayTouchInGame to initialize correctly

</details>