### PR TITLE
[+] 当歌曲已经鸟加时，显示“推到AP可上1分”，以解决特定情况下分数显示的bug

### DIFF
--- a/AquaMai.Core/Resources/Locale.Designer.cs
+++ b/AquaMai.Core/Resources/Locale.Designer.cs
@@ -272,6 +272,15 @@ namespace AquaMai.Core.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to AP =&gt; DXRating += {0}.
+        /// </summary>
+        public static string RatingUpWhenAP {
+            get {
+                return ResourceManager.GetString("RatingUpWhenAP", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Repeat end time cannot be less than repeat start time.
         /// </summary>
         public static string RepeatEndTimeLessThenStartTime {

--- a/AquaMai.Core/Resources/Locale.resx
+++ b/AquaMai.Core/Resources/Locale.resx
@@ -83,6 +83,9 @@
     <data name="RatingUpWhenSSSp" xml:space="preserve">
         <value>SSS+ =&gt; DXRating += {0}</value>
     </data>
+    <data name="RatingUpWhenAP" xml:space="preserve">
+        <value>AP =&gt; DXRating += {0}</value>
+    </data>
     <data name="Skip" xml:space="preserve">
         <value>Skip</value>
     </data>

--- a/AquaMai.Core/Resources/Locale.zh.resx
+++ b/AquaMai.Core/Resources/Locale.zh.resx
@@ -76,6 +76,9 @@
     <data name="RatingUpWhenSSSp" xml:space="preserve">
         <value>推到鸟加可上 {0} 分</value>
     </data>
+    <data name="RatingUpWhenAP" xml:space="preserve">
+        <value>推到AP可上 {0} 分</value>
+    </data>
     <data name="Skip" xml:space="preserve">
         <value>跳过</value>
     </data>


### PR DESCRIPTION
本来的问题如下图所示
<img width="747" height="826" alt="image" src="https://github.com/user-attachments/assets/f4f7d53d-ab44-491e-b60b-c46ff525893d" />
4294927695 = (uint) -1，相当于返回的是“从已经AP推到非AP的鸟加会涨-1分”

改进后的逻辑如下：
1. 先计算推到非AP鸟加所上的分数，如果大于0显示之；
2. 否则，再计算推到AP所上的分数，如果大于0显示之。

容易想到，这种方法对老版本也是有着良好兼容性（因为两步计算的结果必定相等，所以要么都大于0要么都不大于0），所以也没有产生兼容性问题。

## Sourcery 总结

调整评分提升显示，以正确处理已全连(AP)的歌曲：优先计算非全连(AP)分数，然后回退到全连(AP)分数，并只显示正向的分数增长。

Bug 修复：
- 当非全连(AP)分数增长为零或负数时，回退到全连(AP)计算，以防止已全连(AP)的谱面显示负数或未定义的分数。

改进：
- 重构 CalcB50，使其接受一个 AP 标志，统一费率差异计算，并根据用户的最低费率返回一个有符号整数。

文档：
- 为 RatingUpWhenAP 添加本地化字符串条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust rating-up display to handle already-AP songs correctly by computing non-AP first and falling back to AP, showing only positive score increases.

Bug Fixes:
- Prevent negative or undefined score display for already-AP charts by deferring to AP calculation when non-AP increase is zero or negative.

Enhancements:
- Refactor CalcB50 to accept an AP flag, unify rate difference computation, and return a signed integer based on user’s lowest rate.

Documentation:
- Add localized string entry for RatingUpWhenAP.

</details>