### PR TITLE
在普通模式隐藏1879乱码曲

### DIFF
--- a/AquaMai.Mods/Tweaks/TimeSaving/EntryToMusicSelection.cs
+++ b/AquaMai.Mods/Tweaks/TimeSaving/EntryToMusicSelection.cs
@@ -37,6 +37,7 @@ public class EntryToMusicSelection
             var userDatas = ((int[]) [0, 1]).Select(i => Singleton<UserDataManager>.Instance.GetUserData(i));
             if (!userDatas.All(it => it.IsGuest())) return true;
         }
+        GameManager.IsNormalMode = true;
         GameManager.SetMaxTrack();
         SharedInstances.GameMainObject.StartCoroutine(GraduallyIncreaseHeadphoneVolumeCoroutine());
         ___container.processManager.AddProcess(new MusicSelectProcess(___container));

--- a/AquaMai.Mods/UX/Hide1879.cs
+++ b/AquaMai.Mods/UX/Hide1879.cs
@@ -1,0 +1,42 @@
+using HarmonyLib;
+using AquaMai.Config.Attributes;
+using System;
+using MelonLoader;
+using Manager;
+
+namespace AquaMai.Mods.UX;
+
+[ConfigSection(
+    en: "Hide glitch Xaleid◆scopiX in normal mode",
+    zh: "在正常模式中，隐藏乱码曲 Xaleid◆scopiX"
+)]
+public class Hide1879
+{
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(NotesListManager), "CreateNormalNotesList")]
+    public static void CreateNormalNotesList_Postfix()
+    {
+        try
+        {
+            if (!GameManager.IsNormalMode) return; // 仅在 Normal 模式下生效
+
+            var dm = DataManager.Instance;
+            if (dm == null) return;
+            var musicInfo = dm.GetMusic(011879);
+            if (musicInfo == null) return;
+
+            var instance = NotesListManager.Instance;
+            if (instance == null) return;
+            var notesList = instance.GetNotesList();
+            if (notesList != null && notesList.ContainsKey(011879))
+            {
+                notesList.Remove(011879);
+                MelonLogger.Msg($"[Hide 1879] Hide glitch Xaleid◆scopiX in normal mode");
+            }
+        }
+        catch (Exception ex)
+        {
+            MelonLogger.Error($"[Hide 1879] Error: {ex}");
+        }
+    }
+}


### PR DESCRIPTION
## Sourcery 总结

将选曲标记为普通模式，并将故障曲目 Xaleid◆scopiX 从普通音符列表中移除。

新功能：
- 通过 Harmony 补丁在普通模式下隐藏故障曲目 Xaleid◆scopiX (ID 011879)

改进：
- 在进入选曲流程时设置 GameManager.IsNormalMode 标志

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Mark music selection as normal mode and remove the glitch track Xaleid◆scopiX from the normal notes list.

New Features:
- Hide the glitch track Xaleid◆scopiX (ID 011879) in normal mode via a Harmony patch

Enhancements:
- Set the GameManager.IsNormalMode flag when entering the music selection process

</details>