### PR TITLE
[O] DontRuinMyAccount优化：兼容快速重试，和优化右上角UI显示文本

### DIFF
--- a/AquaMai.Core/Resources/Locale.Designer.cs
+++ b/AquaMai.Core/Resources/Locale.Designer.cs
@@ -60,6 +60,24 @@ namespace AquaMai.Core.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to AutoPlay On.
+        /// </summary>
+        public static string AutoplayOn {
+            get {
+                return ResourceManager.GetString("AutoplayOn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Autoplay was used, score will not be saved..
+        /// </summary>
+        public static string AutoplayWasUsed {
+            get {
+                return ResourceManager.GetString("AutoplayWasUsed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You are using AquaMai CI build version. This version is built from the latest mainline code and may contain undocumented configuration changes or potential issues..
         /// </summary>
         public static string CiBuildAlertContent {

--- a/AquaMai.Core/Resources/Locale.resx
+++ b/AquaMai.Core/Resources/Locale.resx
@@ -163,4 +163,10 @@ Use arrow keys to move the position
 Current Movement Speed: {1} (Press [ or ] to adjust)
 Press {2} to switch block or exit adjustment mode</value>
     </data>
+    <data name="AutoplayOn" xml:space="preserve">
+        <value>AutoPlay On</value>
+    </data>
+    <data name="AutoplayWasUsed" xml:space="preserve">
+        <value>Autoplay was used, score will not be saved.</value>
+    </data>
 </root>

--- a/AquaMai.Core/Resources/Locale.zh.resx
+++ b/AquaMai.Core/Resources/Locale.zh.resx
@@ -156,4 +156,10 @@
 当前移动速度：{1}，按下 [ 或 ] 键调整移动速度
 按下 {2} 切换调整的区块和退出调整模式</value>
     </data>
+    <data name="AutoplayOn" xml:space="preserve">
+        <value>AutoPlay开启中</value>
+    </data>
+    <data name="AutoplayWasUsed" xml:space="preserve">
+        <value>Autoplay曾开启过，本曲成绩不会被上传。</value>
+    </data>
 </root>

--- a/AquaMai.Mods/UX/DontRuinMyAccount.cs
+++ b/AquaMai.Mods/UX/DontRuinMyAccount.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using AquaMai.Config.Attributes;
 using AquaMai.Core.Attributes;
 using AquaMai.Core.Helpers;
+using AquaMai.Core.Resources;
 using DB;
 using HarmonyLib;
 using MAI2.Util;
@@ -111,6 +112,14 @@ public class DontRuinMyAccount
             musicid, difficulty, oldScore?.achivement);
     }
 
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(GameProcess), nameof(GameProcess.OnStart))]
+    public static void OnGameStart()
+    {
+        // For compatibility with QuickRetry
+        ignoreScore = false;
+    }
+
     private class NoticeUI : MonoBehaviour
     {
         public void OnGUI()
@@ -126,7 +135,7 @@ public class DontRuinMyAccount
             labelStyle.alignment = TextAnchor.MiddleCenter;
 
             GUI.Box(rect, "");
-            GUI.Label(rect, "AutoPlay");
+            GUI.Label(rect, GameManager.IsAutoPlay() ? Locale.AutoplayOn : Locale.AutoplayWasUsed);
         }
     }
 }


### PR DESCRIPTION
1. 原来版本，在关卡重试后，虽然Autoplay状态被游戏自动关闭，但ignoreScore不会被清空，导致”虽然整首歌都没开过Autoplay但还是传不上成绩“的情况出现。本PR解决了这一问题。
2. 优化右上角显示文本，细化为”正在开启“和“曾经开启过”两种情况，以免引起误解。

## Sourcery 总结

在游戏开始时重置 ignoreScore 标志以兼容 QuickRetry，并优化右上角的 UI 标签，以区分当前活跃的自动播放和过去的使用情况

改进：
- 在游戏开始时将 ignoreScore 重置为 false 以支持 QuickRetry
- 更新 UI 标签，在自动播放活跃时显示“AutoPlay On”，否则显示“Autoplay was used, score will not be saved.”

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reset the ignoreScore flag on game start for QuickRetry compatibility and refine the top-right UI label to distinguish active autoplay from past usage

Enhancements:
- Reset ignoreScore to false at game start to support QuickRetry
- Update UI label to display “AutoPlay On” when active and “Autoplay was used, score will not be saved.” otherwise

</details>