### PR TITLE
[+] 允许忽略闲置时视频广告画面的 5 分钟总时长限制

### DIFF
--- a/AquaMai.Mods/Fancy/IgnoreCommercialTimeout.cs
+++ b/AquaMai.Mods/Fancy/IgnoreCommercialTimeout.cs
@@ -7,7 +7,7 @@ namespace AquaMai.Mods.Fancy;
 [ConfigSection(
     en: "Ignores 5 mins total timeout on commercial screen.",
     zh: "忽略闲置时的视频广告画面的5分钟总时长限制")]
-class IgnoreCommercialTimeout
+public class IgnoreCommercialTimeout
 {
     [HarmonyPrefix]
     [HarmonyPatch(typeof(AdvertiseCommercialProcess), "CheckTotalTimeOut")]


### PR DESCRIPTION
## Sourcery 总结

新功能：
- 引入 IgnoreCommercialTimeout 模组，通过带有可配置元数据的 Harmony 补丁，绕过空闲视频广告屏幕上 5 分钟的总超时

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce IgnoreCommercialTimeout mod that bypasses the 5-minute total timeout on idle video ad screens via a Harmony patch with configurable metadata

</details>