### PR TITLE
使1P的耳机音量可以控制游戏主音量（外放音量）

### DIFF
--- a/AquaMai.Mods/GameSystem/Sound.cs
+++ b/AquaMai.Mods/GameSystem/Sound.cs
@@ -2,6 +2,7 @@ using AquaMai.Config.Attributes;
 using HarmonyLib;
 using Manager;
 using System;
+using MelonLoader;
 
 namespace AquaMai.Mods.GameSystem;
 
@@ -19,6 +20,17 @@ public static class Sound
         zh: "是否启用八声道",
         en: "Enable 8-Channel")]
     private readonly static bool enable8Channel = false;
+    
+    [ConfigEntry(
+        zh: """
+            将1P耳机音量同步给游戏主音量（外放音量）
+            注意：Maimai处理耳机音量的方式未知，若此功能与八声道同时开启，可能导致耳机音量被缩放两次，推荐在仅使用1P且不开启八声道时使用,
+            """,
+        en: """
+            Sync 1P headphone volume to game master volume
+            Maimai's headphone volume handling is unclear. Enabling with 8ch may double-scale headphone volume. It is recommended to use this only in 1P without 8ch.
+            """)]
+    private readonly static bool sync1pVolumeToMaster = false;
 
     [ConfigEntry(
         en: "Music Volume.",
@@ -81,4 +93,67 @@ public static class Sound
             volume = musicVolume;
         }
     }
+    
+    /*
+     * 将1P耳机音量同步给游戏主音量（外放音量）
+     * Sync 1P headphone volume to game master volume
+     *
+     * 注意：Maimai处理耳机音量的方式未知，若此功能与八声道同时开启，可能导致耳机音量被缩放两次，
+     *       推荐在仅使用1P且不开启八声道时使用
+     * Note: Maimai's headphone volume handling is unclear. Enabling with 8ch may double-scale headphone volume.
+     *       It is recommended to use this only in 1P without 8ch.
+     */
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.Initialize))]
+    public static void SoundCtrl_Initialize_Prefix(SoundCtrl __instance)
+    {
+        __instance._masterVolume = 0.05f; // Default headphone volume
+        // MelonLogger.Msg("master volume initialized to 0.05");
+    }
+    
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.SetMasterVolume))]
+    public static void SoundCtrl_SetMasterVolume_Postfix(SoundCtrl __instance, float[] ____headPhoneVolume, float volume)
+    {
+        __instance._masterVolume = __instance.Adjust0_1(volume * ____headPhoneVolume[0]);
+        // MelonLogger.Msg($"master volume set to {__instance._masterVolume}");
+    }
+    
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.ResetMasterVolume))]
+    public static void SoundCtrl_ResetMasterVolume_Postfix(SoundCtrl __instance, float[] ____headPhoneVolume)
+    {
+        __instance._masterVolume = __instance.Adjust0_1(____headPhoneVolume[0]);
+        // MelonLogger.Msg($"master volume reset to {__instance._masterVolume}");
+    }
+    
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.SetHeadPhoneVolume))]
+    public static void SoundCtrl_SetHeadPhoneVolume_Postfix(SoundCtrl __instance, int targerID, float volume)
+    {
+        // MelonLogger.Msg($"setting headphone volume : target {targerID}, volume {volume}");
+        if (targerID == 0)
+        {
+            __instance._masterVolume = __instance.Adjust0_1(volume);
+            // MelonLogger.Msg($"master volume set to {__instance._masterVolume}");
+            // fixme)) 由于每个播放通道的master音量只在切换音频文件时重设，目前调节耳机音量不能及时反映到master
+            // 需要在这里加一段调整所有通道音量的代码，但这样就需要记录开始播放时的volume参数
+        }
+    }
+    
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.Play))]
+    public static void SoundCtrl_Play_Prefix(SoundCtrl __instance, SoundCtrl.PlaySetting setting)
+    {
+        // fixme)) 在这里记录每个文件开始播放时的volume参数
+        if (setting.PlayerID != 3 && setting.PlayerID != 4 && setting.PlayerID != 5)
+        {
+            return;
+        }
+        // PlayerID 3 ~ 5 are not controlled by master volume, so we need a extra scaling
+        // MelonLogger.Msg($"scaling volume: {__instance._masterVolume}");
+        setting.Volume *= __instance._masterVolume;
+    }
+    
+    
 }

--- a/AquaMai.Mods/GameSystem/Sound.cs
+++ b/AquaMai.Mods/GameSystem/Sound.cs
@@ -2,7 +2,6 @@ using AquaMai.Config.Attributes;
 using HarmonyLib;
 using Manager;
 using System;
-using MelonLoader;
 
 namespace AquaMai.Mods.GameSystem;
 
@@ -20,17 +19,6 @@ public static class Sound
         zh: "是否启用八声道",
         en: "Enable 8-Channel")]
     private readonly static bool enable8Channel = false;
-    
-    [ConfigEntry(
-        zh: """
-            将1P耳机音量同步给游戏主音量（外放音量）
-            注意：Maimai处理耳机音量的方式未知，若此功能与八声道同时开启，可能导致耳机音量被缩放两次，推荐在仅使用1P且不开启八声道时使用,
-            """,
-        en: """
-            Sync 1P headphone volume to game master volume
-            Maimai's headphone volume handling is unclear. Enabling with 8ch may double-scale headphone volume. It is recommended to use this only in 1P without 8ch.
-            """)]
-    private readonly static bool sync1pVolumeToMaster = false;
 
     [ConfigEntry(
         en: "Music Volume.",
@@ -93,67 +81,4 @@ public static class Sound
             volume = musicVolume;
         }
     }
-    
-    /*
-     * 将1P耳机音量同步给游戏主音量（外放音量）
-     * Sync 1P headphone volume to game master volume
-     *
-     * 注意：Maimai处理耳机音量的方式未知，若此功能与八声道同时开启，可能导致耳机音量被缩放两次，
-     *       推荐在仅使用1P且不开启八声道时使用
-     * Note: Maimai's headphone volume handling is unclear. Enabling with 8ch may double-scale headphone volume.
-     *       It is recommended to use this only in 1P without 8ch.
-     */
-    [HarmonyPrefix]
-    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.Initialize))]
-    public static void SoundCtrl_Initialize_Prefix(SoundCtrl __instance)
-    {
-        __instance._masterVolume = 0.05f; // Default headphone volume
-        // MelonLogger.Msg("master volume initialized to 0.05");
-    }
-    
-    [HarmonyPostfix]
-    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.SetMasterVolume))]
-    public static void SoundCtrl_SetMasterVolume_Postfix(SoundCtrl __instance, float[] ____headPhoneVolume, float volume)
-    {
-        __instance._masterVolume = __instance.Adjust0_1(volume * ____headPhoneVolume[0]);
-        // MelonLogger.Msg($"master volume set to {__instance._masterVolume}");
-    }
-    
-    [HarmonyPostfix]
-    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.ResetMasterVolume))]
-    public static void SoundCtrl_ResetMasterVolume_Postfix(SoundCtrl __instance, float[] ____headPhoneVolume)
-    {
-        __instance._masterVolume = __instance.Adjust0_1(____headPhoneVolume[0]);
-        // MelonLogger.Msg($"master volume reset to {__instance._masterVolume}");
-    }
-    
-    [HarmonyPostfix]
-    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.SetHeadPhoneVolume))]
-    public static void SoundCtrl_SetHeadPhoneVolume_Postfix(SoundCtrl __instance, int targerID, float volume)
-    {
-        // MelonLogger.Msg($"setting headphone volume : target {targerID}, volume {volume}");
-        if (targerID == 0)
-        {
-            __instance._masterVolume = __instance.Adjust0_1(volume);
-            // MelonLogger.Msg($"master volume set to {__instance._masterVolume}");
-            // fixme)) 由于每个播放通道的master音量只在切换音频文件时重设，目前调节耳机音量不能及时反映到master
-            // 需要在这里加一段调整所有通道音量的代码，但这样就需要记录开始播放时的volume参数
-        }
-    }
-    
-    [HarmonyPrefix]
-    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.Play))]
-    public static void SoundCtrl_Play_Prefix(SoundCtrl __instance, SoundCtrl.PlaySetting setting)
-    {
-        // fixme)) 在这里记录每个文件开始播放时的volume参数
-        if (setting.PlayerID != 3 && setting.PlayerID != 4 && setting.PlayerID != 5)
-        {
-            return;
-        }
-        // PlayerID 3 ~ 5 are not controlled by master volume, so we need a extra scaling
-        // MelonLogger.Msg($"scaling volume: {__instance._masterVolume}");
-        setting.Volume *= __instance._masterVolume;
-    }
-    
-    
 }

--- a/AquaMai.Mods/GameSystem/VolumeSync.cs
+++ b/AquaMai.Mods/GameSystem/VolumeSync.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using AquaMai.Config.Attributes;
+using HarmonyLib;
+using Manager;
+using MelonLoader;
+using Type = System.Type;
+
+namespace AquaMai.Mods.GameSystem;
+
+[ConfigSection(
+    zh: """
+        将1P耳机音量同步给游戏主音量（外放音量）
+        注意：若此功能与八声道同时开启，会导致内置耳机声道的音量被缩放两次，推荐在仅使用1P且不开启八声道时使用,
+        """,
+    en: """
+        Sync 1P headphone volume to game master volume
+        Note: Enabling with 8ch will double-scale internal headphone volume. Recommended to use this only in 1P without 8ch.
+        """)]
+public static class VolumeSync
+{
+    public static class PlayerObjHelper
+    {
+        public static void Init()
+        {
+            var playerObjType = typeof(SoundCtrl).GetNestedType("PlayerObj", AccessTools.all);
+
+            UnboundIsReady = MethodInvoker.GetHandler(
+                AccessTools.DeclaredMethod(playerObjType, "IsReady", [])
+            );
+
+            UnboundSetAisac = MethodInvoker.GetHandler(
+                AccessTools.DeclaredMethod(playerObjType, "SetAisac", [typeof(int), typeof(float)])
+            );
+
+            UnboundTargetIDAccessor = AccessTools.FieldRefAccess<int>(playerObjType, "TargetID");
+            UnboundNeedUpdateAccessor = AccessTools.FieldRefAccess<bool>(playerObjType, "NeedUpdate");
+            UnboundPlayerDictAccessor = AccessTools.FieldRefAccess<SoundCtrl, IDictionary>("_players");
+        }
+
+        public static FastInvokeHandler UnboundIsReady;
+        public static FastInvokeHandler UnboundSetAisac;
+
+        public static AccessTools.FieldRef<object, int> UnboundTargetIDAccessor;
+        public static AccessTools.FieldRef<object, bool> UnboundNeedUpdateAccessor;
+        public static AccessTools.FieldRef<SoundCtrl, IDictionary> UnboundPlayerDictAccessor;
+    }
+
+    private static float[] _playerVolumes;
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.Initialize))]
+    public static void SoundCtrl_Initialize_Prefix(SoundCtrl __instance, SoundCtrl.InitParam param)
+    {
+        MelonLogger.Msg("VolumeSync - Initializing");
+        __instance._masterVolume = 0.05f; // Default headphone volume
+
+        // Initialization
+        try
+        {
+            PlayerObjHelper.Init();
+            _playerVolumes = new float[param.PlayerNum];
+            for (var i = 0; i < param.PlayerNum; i++)
+            {
+                _playerVolumes[i] = 1f;
+            }
+        }
+        catch (Exception e)
+        {
+            MelonLogger.Error(e);
+        }
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.SetMasterVolume))]
+    public static void SoundCtrl_SetMasterVolume_Postfix(SoundCtrl __instance, float[] ____headPhoneVolume,
+        float volume)
+    {
+        __instance._masterVolume = __instance.Adjust0_1(volume * ____headPhoneVolume[0]);
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.ResetMasterVolume))]
+    public static void SoundCtrl_ResetMasterVolume_Postfix(SoundCtrl __instance, float[] ____headPhoneVolume)
+    {
+        __instance._masterVolume = __instance.Adjust0_1(____headPhoneVolume[0]);
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.SetHeadPhoneVolume))]
+    public static void SoundCtrl_SetHeadPhoneVolume_Postfix(SoundCtrl __instance, int targerID, float volume)
+    {
+        if (targerID != 0) return;
+
+        __instance._masterVolume = __instance.Adjust0_1(volume);
+
+        var playerDict = PlayerObjHelper.UnboundPlayerDictAccessor(__instance);
+        foreach (DictionaryEntry pair in playerDict)
+        {
+            var player = pair.Value; // SoundCtrl.PlayerObj
+            var key = (int)pair.Key;
+            var newVolume = __instance.Adjust0_1(__instance._masterVolume * _playerVolumes[key]);
+
+            if (!(bool)PlayerObjHelper.UnboundIsReady(player)) continue;
+
+            switch (PlayerObjHelper.UnboundTargetIDAccessor(player))
+            {
+                case 0:
+                    PlayerObjHelper.UnboundSetAisac(player, 4, newVolume);
+                    break;
+                case 1:
+                    PlayerObjHelper.UnboundSetAisac(player, 5, newVolume);
+                    break;
+                case 2:
+                    PlayerObjHelper.UnboundSetAisac(player, 4, newVolume);
+                    PlayerObjHelper.UnboundSetAisac(player, 5, newVolume);
+                    break;
+            }
+
+            PlayerObjHelper.UnboundNeedUpdateAccessor(player) = true;
+        }
+
+        // The code above is supposed to do following things,
+        // but SoundCtrl.PlayerObj is a private type so we need these unbound method bullshit.
+        // By the way, MethodInvoker is an IL-based delegate, which is faster than invoking MethodInfo every time
+        // (Traverse only cache MethodInfo, invoking is still using MethodInfo.Invoke)
+        // ================================================================================
+        // foreach (KeyValuePair<int, SoundCtrl.PlayerObj> player in this._players)
+        // {
+        //     if (player.Value.IsReady())
+        //     {
+        //         switch (player.Value.TargetID)
+        //         {
+        //             case 0:
+        //                 player.Value.SetAisac(4, volume);
+        //                 break;
+        //             case 1:
+        //                 player.Value.SetAisac(5, volume);
+        //                 break;
+        //             case 2:
+        //                 player.Value.SetAisac(4, volume);
+        //                 player.Value.SetAisac(5, volume);
+        //                 break;
+        //         }
+        //         player.Value.NeedUpdate = true;
+        //     }
+        // }
+        // ================================================================================
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SoundCtrl), nameof(SoundCtrl.Play))]
+    public static void SoundCtrl_Play_Prefix(SoundCtrl __instance, SoundCtrl.PlaySetting setting)
+    {
+        _playerVolumes[setting.PlayerID] = (setting.Volume < 0f) ? 1.0f : setting.Volume;
+
+        if (setting.PlayerID != 3 && setting.PlayerID != 4 && setting.PlayerID != 5)
+        {
+            return;
+        }
+
+        // PlayerID 3 ~ 5 are not controlled by master volume, so we need a extra scaling
+        // MelonLogger.Msg($"scaling volume: {__instance._masterVolume}");
+        setting.Volume *= __instance._masterVolume;
+    }
+}


### PR DESCRIPTION
新功能是GameSystem.VolumeSync

## Sourcery 总结

添加一个基于 Harmony 的 VolumeSync mod，通过拦截 SoundCtrl 方法并更新每个玩家的音频通道，将 1P 耳机音量与游戏主音量（外部）关联起来。

新功能：
- 实时将 1P 耳机音量与游戏主音量同步，并相应地调整所有玩家的音频

改进：
- 初始化默认耳机和主音量，并维护每个玩家的音量状态
- 利用基于 IL 的委托和反射来访问和修改私有的 SoundCtrl.PlayerObj 内部实现，以提高性能

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a Harmony-based VolumeSync mod to link 1P headphone volume with the game master (external) volume by intercepting SoundCtrl methods and updating per-player audio channels.

New Features:
- Sync 1P headphone volume to the game's master volume in real time, scaling all players' audio accordingly

Enhancements:
- Initialize default headphone and master volumes and maintain per-player volume states
- Leverage IL-based delegates and reflection to access and modify private SoundCtrl.PlayerObj internals for improved performance

</details>