### PR TITLE
把JudgeAccuracyInfo生成的txt文件移动到子文件夹内

### DIFF
--- a/AquaMai.Mods/UX/JudgeAccuracyInfo.cs
+++ b/AquaMai.Mods/UX/JudgeAccuracyInfo.cs
@@ -151,7 +151,9 @@ public class JudgeAccuracyInfo
             if (!____userData[idx].IsEntry) continue;
             
             var fileName = $"Acc_Track_{GameManager.MusicTrackNumber}_Player_{idx}.txt";
-            var filePath = Path.Combine(Environment.CurrentDirectory, fileName);
+            var directoryPath = Path.Combine(Environment.CurrentDirectory, "JudgeAccuracyInfo");
+            if (!Directory.Exists(directoryPath)) Directory.CreateDirectory(directoryPath);
+            var filePath = Path.Combine(directoryPath, fileName);
             
             using (var writer = new StreamWriter(filePath))
             {


### PR DESCRIPTION
不然的话，如图所示，现在文件都散落在Package文件夹内，比较不美观（）
本PR将它们都改为在`JudgeAccuracyInfo`子文件夹内生成
<img width="861" height="665" alt="image" src="https://github.com/user-attachments/assets/32b67838-f7c9-4b2e-aa41-6299075b28e1" />

## Sourcery 总结

增强功能：
- 在当前目录下创建“JudgeAccuracyInfo”子目录，并将所有生成的 .txt 文件写入其中，如果该文件夹不存在则创建它

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Create a “JudgeAccuracyInfo” subdirectory under the current directory and write all generated .txt files there, creating the folder if missing

</details>