### PR TITLE
[+] config entry names

### DIFF
--- a/AquaMai.Config.Interfaces/IConfigComment.cs
+++ b/AquaMai.Config.Interfaces/IConfigComment.cs
@@ -4,5 +4,10 @@ public interface IConfigComment
 {
     string CommentEn { get; init; }
     string CommentZh { get; init; }
+    // 为了使旧版 MCM 能编辑新版 AquaMai 的配置，这里不能加 init;
+    // 如果加了，旧版 MCM 会因为构造函数执行时找不到接口里的 setter 定义而报错（我也不知道为什么 C# 在执行时还会检查接口）
+    // 然而，前两个已经加了。如果再删掉的话，也会炸掉。现在能保持最佳兼容性的方法就是以后新增的东西都不需要 init; IConfigSectionAttribute 里就都是 get;
+    // 接口里如果不写的话，就不会序列化了
+    string NameZh { get; }
     public string GetLocalized(string lang);
 }

--- a/AquaMai.Config.Interfaces/IConfigComment.cs
+++ b/AquaMai.Config.Interfaces/IConfigComment.cs
@@ -4,7 +4,5 @@ public interface IConfigComment
 {
     string CommentEn { get; init; }
     string CommentZh { get; init; }
-    string NameZh { get; init; }
     public string GetLocalized(string lang);
-    public string GetLocalizedForComment(string lang);
 }

--- a/AquaMai.Config.Interfaces/IConfigComment.cs
+++ b/AquaMai.Config.Interfaces/IConfigComment.cs
@@ -4,5 +4,7 @@ public interface IConfigComment
 {
     string CommentEn { get; init; }
     string CommentZh { get; init; }
+    string NameZh { get; init; }
     public string GetLocalized(string lang);
+    public string GetLocalizedForComment(string lang);
 }

--- a/AquaMai.Config.Interfaces/IConfigSectionAttribute.cs
+++ b/AquaMai.Config.Interfaces/IConfigSectionAttribute.cs
@@ -6,4 +6,5 @@ public interface IConfigSectionAttribute
     bool ExampleHidden { get; }
     bool DefaultOn { get; }
     bool AlwaysEnabled { get; }
+    string Name { get; }
 }

--- a/AquaMai.Config/ApiVersion.cs
+++ b/AquaMai.Config/ApiVersion.cs
@@ -5,5 +5,5 @@ public static class ApiVersion
     // Using a raw string for API version instead of a constant for maximum compatibility.
     // When breaking changes are made, increment the major version.
     // When new APIs are added in a backwards-compatible but non-forward-compatible manner, increment the minor version.
-    public const string Version = "1.0";
+    public const string Version = "1.1";
 }

--- a/AquaMai.Config/Attributes/ConfigComment.cs
+++ b/AquaMai.Config/Attributes/ConfigComment.cs
@@ -1,9 +1,10 @@
 using System;
+using System.Collections.Generic;
 using AquaMai.Config.Interfaces;
 
 namespace AquaMai.Config.Attributes;
 
-public record ConfigComment(string CommentEn, string CommentZh) : IConfigComment
+public record ConfigComment(string CommentEn, string CommentZh, string NameZh) : IConfigComment
 {
     public string GetLocalized(string lang) => lang switch
     {
@@ -11,4 +12,22 @@ public record ConfigComment(string CommentEn, string CommentZh) : IConfigComment
         "zh" => CommentZh ?? "",
         _ => throw new ArgumentException($"Unsupported language: {lang}")
     };
+
+    public string GetLocalizedForComment(string lang)
+    {
+        switch (lang)
+        {
+            case "en":
+                return CommentEn ?? "";
+            case "zh":
+                List<string> lines = new();
+                if (!string.IsNullOrEmpty(NameZh))
+                    lines.Add(NameZh);
+                if (!string.IsNullOrEmpty(CommentZh))
+                    lines.Add(CommentZh);
+                return string.Join("\n", lines);
+            default:
+                throw new ArgumentException($"Unsupported language: {lang}");
+        }
+    }
 }

--- a/AquaMai.Config/Attributes/ConfigComment.cs
+++ b/AquaMai.Config/Attributes/ConfigComment.cs
@@ -6,14 +6,7 @@ namespace AquaMai.Config.Attributes;
 
 public record ConfigComment(string CommentEn, string CommentZh, string NameZh) : IConfigComment
 {
-    public string GetLocalized(string lang) => lang switch
-    {
-        "en" => CommentEn ?? "",
-        "zh" => CommentZh ?? "",
-        _ => throw new ArgumentException($"Unsupported language: {lang}")
-    };
-
-    public string GetLocalizedForComment(string lang)
+    public string GetLocalized(string lang)
     {
         switch (lang)
         {

--- a/AquaMai.Config/Attributes/ConfigEntryAttribute.cs
+++ b/AquaMai.Config/Attributes/ConfigEntryAttribute.cs
@@ -11,6 +11,7 @@ public enum SpecialConfigEntry
 
 [AttributeUsage(AttributeTargets.Field)]
 public class ConfigEntryAttribute(
+    string name = null,
     string en = null,
     string zh = null,
     // NOTE: Don't use this argument to hide any useful options.
@@ -19,7 +20,7 @@ public class ConfigEntryAttribute(
     // NOTE: Use this argument to mark special config entries that need special handling.
     SpecialConfigEntry specialConfigEntry = SpecialConfigEntry.None) : Attribute, IConfigEntryAttribute
 {
-    public IConfigComment Comment { get; } = new ConfigComment(en, zh);
+    public IConfigComment Comment { get; } = new ConfigComment(en, zh, name);
     public bool HideWhenDefault { get; } = hideWhenDefault;
     public SpecialConfigEntry SpecialConfigEntry { get; } = specialConfigEntry;
 }

--- a/AquaMai.Config/Attributes/ConfigSectionAttribute.cs
+++ b/AquaMai.Config/Attributes/ConfigSectionAttribute.cs
@@ -13,10 +13,13 @@ public class ConfigSectionAttribute(
     bool defaultOn = false,
     // NOTE: You probably shouldn't use this. Only the "General" section is using this.
     //       Implies defaultOn = true.
-    bool alwaysEnabled = false) : Attribute, IConfigSectionAttribute
+    bool alwaysEnabled = false,
+    // 用于在 MaiChartManager 中显示的名称，尽量控制在八个字以内吧
+    string name = null) : Attribute, IConfigSectionAttribute
 {
-    public IConfigComment Comment { get; } = new ConfigComment(en, zh);
+    public IConfigComment Comment { get; } = new ConfigComment(en, zh, name);
     public bool ExampleHidden { get; } = exampleHidden;
     public bool DefaultOn { get; } = defaultOn || alwaysEnabled;
     public bool AlwaysEnabled { get; } = alwaysEnabled;
+    public string Name { get; } = name;
 }

--- a/AquaMai.Config/ConfigSerializer.cs
+++ b/AquaMai.Config/ConfigSerializer.cs
@@ -156,7 +156,7 @@ public class ConfigSerializer(IConfigSerializer.Options Options) : IConfigSerial
     {
         if (comment != null)
         {
-            AppendComment(sb, comment.GetLocalizedForComment(Options.Lang));
+            AppendComment(sb, comment.GetLocalized(Options.Lang));
         }
     }
 

--- a/AquaMai.Config/ConfigSerializer.cs
+++ b/AquaMai.Config/ConfigSerializer.cs
@@ -156,7 +156,7 @@ public class ConfigSerializer(IConfigSerializer.Options Options) : IConfigSerial
     {
         if (comment != null)
         {
-            AppendComment(sb, comment.GetLocalized(Options.Lang));
+            AppendComment(sb, comment.GetLocalizedForComment(Options.Lang));
         }
     }
 

--- a/AquaMai.Mods/DeprecationWarning.cs
+++ b/AquaMai.Mods/DeprecationWarning.cs
@@ -3,6 +3,7 @@ using AquaMai.Config.Attributes;
 namespace AquaMai.Mods;
 
 [ConfigSection(
+    name: "废弃配置项",
     en: """
         These options have been deprecated and no longer work in the current version.
         Remove them to get rid of the warning message at startup.

--- a/AquaMai.Mods/Enhancement/ServerResources.cs
+++ b/AquaMai.Mods/Enhancement/ServerResources.cs
@@ -10,6 +10,7 @@ using AquaMai.Config.Attributes;
 using AquaMai.Core.Helpers;
 using AquaMai.Mods.Types;
 using HarmonyLib;
+using JetBrains.Annotations;
 using MelonLoader;
 using MelonLoader.TinyJSON;
 using Monitor;
@@ -36,8 +37,8 @@ public class ServerResources
 
     private class ServerResourcesEntry : ConditionalMessage
     {
-        public string url;
-        public string sign;
+        [CanBeNull] public string url = null;
+        [CanBeNull] public string sign = null;
     }
 
     private class ServerResourcesData

--- a/AquaMai.Mods/Fancy/CustomButton.cs
+++ b/AquaMai.Mods/Fancy/CustomButton.cs
@@ -12,12 +12,14 @@ using Monitor.Entry.Parts;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
+    name: "自定义按钮",
     en: "Custom button textures\nLoad button textures from specified directory",
-    zh: "自定义按钮贴图\n从指定目录加载按钮贴图")]
+    zh: "从指定目录加载按钮贴图")]
 
 public class CustomButton
 {
     [ConfigEntry(
+        name: "贴图目录",
         en: "path to button texture directory",
         zh: "按钮贴图的目录")]
     private static readonly string buttonDir = "LocalAssets/Buttons";

--- a/AquaMai.Mods/Fancy/CustomCreditsString.cs
+++ b/AquaMai.Mods/Fancy/CustomCreditsString.cs
@@ -6,17 +6,20 @@ using Monitor;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
+    name: "自定义点数文本",
     en: "Set the \"CREDIT(S)\" string displayed at the middle and top-right corner of the screen.",
     zh: "自定义中间和右上角的 \"CREDIT(S)\"（可用点数）文本")]
 public class CustomCreditsString
 {
     [ConfigEntry(
+        name: "点数文本",
         en: "Custom string to replace the \"CREDIT(S)\". Empty for a blank string.",
         zh: "用于替换 \"CREDIT(S)\" 的自定义文本，留空则为空白"
     )]
     private static readonly string creditsString = "";
 
     [ConfigEntry(
+        name: "隐藏点数",
         en: "Hide the number of credits after the \"CREDITS(S)\" string.",
         zh: "隐藏 \"CREDIT(S)\" 后的可用点数数量"
     )]

--- a/AquaMai.Mods/Fancy/CustomLogo.cs
+++ b/AquaMai.Mods/Fancy/CustomLogo.cs
@@ -12,16 +12,19 @@ using UnityEngine.UI;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
+    name: "自定义 Logo",
     en: "Replace the \"SEGA\" and \"ALL.Net\" logos with custom ones.",
     zh: "用自定义的图片替换「SEGA」和「ALL.Net」的标志")]
 public class CustomLogo
 {
     [ConfigEntry(
+        name: "SEGA Logo 目录",
         en: "Replace the \"SEGA\" logo with a random PNG image from this directory.",
         zh: "从此目录中随机选择一张 PNG 图片用于「SEGA」标志")]
     private static readonly string segaLogoDir = "LocalAssets/SegaLogo";
 
     [ConfigEntry(
+        name: "ALL.Net Logo 目录",
         en: "Replace the \"ALL.Net\" logo with a random PNG image from this directory.",
         zh: "从此目录中随机选择一张 PNG 图片用于「ALL.Net」标志")]
     private static readonly string allNetLogoDir = "LocalAssets/AllNetLogo";

--- a/AquaMai.Mods/Fancy/CustomPlaceName.cs
+++ b/AquaMai.Mods/Fancy/CustomPlaceName.cs
@@ -5,6 +5,7 @@ using Manager;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
+    name: "自定义店铺名",
     en: """
         Custom shop name in photo.
         Also enable shop name display in SDGA.
@@ -15,7 +16,7 @@ namespace AquaMai.Mods.Fancy;
         """)]
 public class CustomPlaceName
 {
-    [ConfigEntry]
+    [ConfigEntry(name: "店铺名称")]
     private static readonly string placeName = "";
 
     [HarmonyPostfix]

--- a/AquaMai.Mods/Fancy/CustomSkins.cs
+++ b/AquaMai.Mods/Fancy/CustomSkins.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
+    name: "自定义皮肤",
     en: """
         Provide the ability to use custom skins (advanced feature).
         Load skin textures from custom paths.
@@ -22,7 +23,7 @@ namespace AquaMai.Mods.Fancy;
         """)]
 public class CustomSkins
 {
-    [ConfigEntry]
+    [ConfigEntry(name: "皮肤目录")]
     private static readonly string skinsDir = "LocalAssets/Skins";
 
     private static readonly List<string> ImageExts = [".png", ".jpg", ".jpeg"];

--- a/AquaMai.Mods/Fancy/CustomTrackStartDiff.cs
+++ b/AquaMai.Mods/Fancy/CustomTrackStartDiff.cs
@@ -9,6 +9,7 @@ using UnityEngine.UI;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
+    name: "自定义难度显示",
     en: """
         Custom track start difficulty image (not really custom difficulty).
         Requires CustomSkins to be enabled.

--- a/AquaMai.Mods/Fancy/CustomVersionString.cs
+++ b/AquaMai.Mods/Fancy/CustomVersionString.cs
@@ -4,11 +4,12 @@ using HarmonyLib;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
+    name: "自定义版本文本",
     en: "Set the version string displayed at the top-right corner of the screen.",
     zh: "把右上角的版本更改为自定义文本")]
 public class CustomVersionString
 {
-    [ConfigEntry]
+    [ConfigEntry(name: "版本文本")]
     private static readonly string versionString = "";
 
     /*

--- a/AquaMai.Mods/Fancy/DemoMaster.cs
+++ b/AquaMai.Mods/Fancy/DemoMaster.cs
@@ -8,6 +8,7 @@ using Process;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
+    name: "闲置播放紫谱",
     en: "Play \"Master\" difficulty on Demo screen.",
     zh: "在闲置时的演示画面上播放紫谱而不是绿谱")]
 public class DemoMaster

--- a/AquaMai.Mods/Fancy/GamePlay/AlignCircleSlideJudgeDisplay.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/AlignCircleSlideJudgeDisplay.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "圆弧判定对齐",
     en: """
         Make the judgment display of circular Slides align precisely with the judgment line (originally a bit off).
         Just like in majdata.

--- a/AquaMai.Mods/Fancy/GamePlay/BreakSlideJudgeBlink.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/BreakSlideJudgeBlink.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "Break 星星闪烁",
     en: """
         This Patch makes the Critical judgment of BreakSlide also flicker like BreakTap.
         Recommended to use with custom skins (otherwise the visual effect may not be good).

--- a/AquaMai.Mods/Fancy/GamePlay/CustomNoteTypes/CustomNoteTypes.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/CustomNoteTypes/CustomNoteTypes.cs
@@ -17,8 +17,8 @@ namespace AquaMai.Mods.Fancy.GamePlay.CustomNoteTypes;
 
 [ConfigCollapseNamespace]
 [ConfigSection(
-    en: "Custom Note Types.",
-    zh: "自定义 Note 类型"
+    name: "自定义 Note 类型",
+    en: "Custom Note Types."
 )]
 public class CustomNoteTypes
 {

--- a/AquaMai.Mods/Fancy/GamePlay/DisableTrackStartTabs.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/DisableTrackStartTabs.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "隐藏曲目信息",
     en: """
         Disable the TRACK X text, DX/Standard display box, and the derakkuma at the bottom of the screen in the song start screen.
         For recording chart confirmation.

--- a/AquaMai.Mods/Fancy/GamePlay/ExtendNotesPool.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/ExtendNotesPool.cs
@@ -11,12 +11,15 @@ using UnityEngine;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "扩展音符池",
     en: "Add notes sprite to the pool to prevent use up.",
-    zh: "增加更多待命的音符贴图，防止奇怪的自制谱用完音符贴图池")]
+    zh: "增加更多待命的音符贴图，防止奇怪的自制谱用完音符贴图池",
+    defaultOn: true)]
 [EnableGameVersion(23000)]
 public class ExtendNotesPool
 {
     [ConfigEntry(
+        name: "增加数量",
         en: "Number of objects to add.",
         zh: "要增加的对象数量")]
     private readonly static int count = 128;

--- a/AquaMai.Mods/Fancy/GamePlay/FanJudgeFlip.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/FanJudgeFlip.cs
@@ -5,6 +5,7 @@ using Monitor;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "WiFi 判定翻转",
     en: """
         Make the judgment display of WiFi Slide different in up and down (originally all WiFi judgment displays are towards the center), just like in majdata.
         The reason for this bug is that SEGA forgot to assign EndButtonId to WiFi.

--- a/AquaMai.Mods/Fancy/GamePlay/FixJudgeTouchHoldInNormalArea.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/FixJudgeTouchHoldInNormalArea.cs
@@ -12,6 +12,7 @@ using Monitor;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "修复非 C 区 Hold",
     en: "Enable the game to correctly judge Touch Hold outside the C zone. Experimental implementation, reported to be unstable",
     zh: "使游戏可以正常判定非 C 区的 Touch Hold。实验性实现，据反馈不稳定"
 )]

--- a/AquaMai.Mods/Fancy/GamePlay/HideHanabi.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/HideHanabi.cs
@@ -7,8 +7,8 @@ using UnityEngine;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
-    en: "Hide hanabi completely.",
-    zh: "完全隐藏烟花")]
+    name: "隐藏烟花",
+    en: "Hide hanabi completely.")]
 public class HideHanabi
 {
     [HarmonyPatch(typeof(TapCEffect), "SetUpParticle")]

--- a/AquaMai.Mods/Fancy/GamePlay/JudgeDisplay4B.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/JudgeDisplay4B.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "精细判定显示",
     en: """
         More detailed judgment display.
         Requires CustomSkins to be enabled and the resource file to be downloaded.

--- a/AquaMai.Mods/Fancy/GamePlay/RealisticRandomJudge.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/RealisticRandomJudge.cs
@@ -5,6 +5,7 @@ using Manager;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "真随机判定",
     en: """
         Make the AutoPlay random judgment mode really randomize all judgments (down to sub-judgments).
         The original random judgment will only produce all 15 judgment results from Miss(TooFast) ~ Critical ~ Miss(TooLate).

--- a/AquaMai.Mods/Fancy/GamePlay/ReviveFinaleVSlide.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/ReviveFinaleVSlide.cs
@@ -7,6 +7,7 @@ using Manager;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "允许 1v1 星星",
     en: "Allow v-shaped slide with the same starting and ending point, such as \"1v1\" in Simai notation",
     zh: "允许形如 \"1v1\" 的，起点和终点相同的 v 型星星")]
 public static class ReviveFinaleVSlide

--- a/AquaMai.Mods/Fancy/GamePlay/SlideArrowAnimation.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/SlideArrowAnimation.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "星星缩入动画",
     en: "Make the Slide Track disappear with an inward-shrinking animation, similar to AstroDX.",
     zh: "使 Slide Track 消失时有类似 AstroDX 一样的向内缩入的动画")]
 public class SlideArrowAnimation

--- a/AquaMai.Mods/Fancy/GamePlay/SlideFadeInTweak.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/SlideFadeInTweak.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "星星渐入",
     zh: "让星星在启动拍等待期间从 50% 透明度渐入为 100%，取代原本在击打星星头时就完成渐入",
     en: "Slides will fade in instead of instantly appearing.")]
 public class SlideFadeInTweak

--- a/AquaMai.Mods/Fancy/GamePlay/SlideLayerReverse.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/SlideLayerReverse.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "反转星星层级",
     en: """
         Invert the Slide hierarchy, so that the new Slide appears on top like Maimai classic.
         Enable to support color changing effects achieved by overlaying multiple stars.

--- a/AquaMai.Mods/Fancy/GamePlay/TrackStartProcessTweak.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/TrackStartProcessTweak.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 namespace AquaMai.Mods.Fancy.GamePlay;
 
 [ConfigSection(
+    name: "延迟开始动画",
     en: """
         Delayed the animation of the song start screen.
         For recording chart confirmation.

--- a/AquaMai.Mods/Fancy/HideMask.cs
+++ b/AquaMai.Mods/Fancy/HideMask.cs
@@ -6,8 +6,8 @@ using UnityEngine;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
-    en: "Remove the circle mask of the game screen.",
-    zh: "移除游戏画面的圆形遮罩")]
+    name: "移除圆形遮罩",
+    en: "Remove the circle mask of the game screen.")]
 public class HideMask
 {
     [HarmonyPrefix]

--- a/AquaMai.Mods/Fancy/RandomBgm.cs
+++ b/AquaMai.Mods/Fancy/RandomBgm.cs
@@ -12,6 +12,7 @@ using MelonLoader;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
+    name: "随机 BGM",
     en: """
         Random BGM.
         Put Mai2Cue.{acb,awb} of old version of the game in the configured directory and rename them.
@@ -23,7 +24,7 @@ namespace AquaMai.Mods.Fancy;
         """)]
 public class RandomBgm
 {
-    [ConfigEntry]
+    [ConfigEntry(name: "Mai2Cue 目录")]
     private static readonly string mai2CueDir = "LocalAssets/Mai2Cue";
 
     private static List<string> _acbs = new List<string>();

--- a/AquaMai.Mods/Fancy/SetFade.cs
+++ b/AquaMai.Mods/Fancy/SetFade.cs
@@ -11,13 +11,15 @@ using MelonLoader;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
+    name: "转场动画",
     en: "Set Fade Animation",
-    zh: "设置转场动画"
+    zh: "修改转场动画为其他变种"
 )]
 
 public class SetFade
 {
     [ConfigEntry(
+        name: "转场类型",
         en: "Type: Non-Plus 0, Plus 1. (If SDEZ 1.60 can choose Festa 2)",
         zh: "类型: Non-Plus 0, Plus 1. (SDEZ 1.60 限定可选 Festa 2)")]
     public static readonly int FadeType = 0;

--- a/AquaMai.Mods/Fancy/Triggers.cs
+++ b/AquaMai.Mods/Fancy/Triggers.cs
@@ -7,11 +7,13 @@ using Process;
 namespace AquaMai.Mods.Fancy;
 
 [ConfigSection(
+    name: "触发器",
     en: "Triggers for executing commands at certain events.",
     zh: "在一定时机执行命令的触发器")]
 public class Triggers
 {
     [ConfigEntry(
+        name: "闲置时执行",
         en: "Execute some command on game idle.",
         zh: """
             在游戏闲置的时候执行指定的命令脚本
@@ -20,6 +22,7 @@ public class Triggers
     private static readonly string execOnIdle = "";
 
     [ConfigEntry(
+        name: "登录时执行",
         en: "Execute some command on game start.",
         zh: "在玩家登录的时候执行指定的命令脚本")]
     private static readonly string execOnEntry = "";

--- a/AquaMai.Mods/Fix/Common.cs
+++ b/AquaMai.Mods/Fix/Common.cs
@@ -20,7 +20,7 @@ namespace AquaMai.Mods.Fix;
 [ConfigSection(exampleHidden: true, defaultOn: true)]
 public class Common
 {
-    [ConfigEntry] private readonly static bool preventIniFileClear = true;
+    [ConfigEntry(name: "防止配置清空")] private readonly static bool preventIniFileClear = true;
 
     [EnableIf(nameof(preventIniFileClear))]
     [HarmonyPrefix]
@@ -30,7 +30,7 @@ public class Common
         return false;
     }
 
-    [ConfigEntry] private readonly static bool fixDebugInput = true;
+    [ConfigEntry(name: "修复调试输入")] private readonly static bool fixDebugInput = true;
 
     private static bool FixDebugKeyboardInput => fixDebugInput && !KeyMap.disableDebugInput;
 
@@ -70,7 +70,7 @@ public class Common
         return false;
     }
 
-    [ConfigEntry] private readonly static bool bypassCakeHashCheck = true;
+    [ConfigEntry(name: "绕过 Cake 检查")] private readonly static bool bypassCakeHashCheck = true;
 
     [EnableIf(nameof(bypassCakeHashCheck))]
     [HarmonyPostfix]
@@ -85,7 +85,7 @@ public class Common
         }
     }
 
-    [ConfigEntry] private readonly static bool restoreCertificateValidation = true;
+    [ConfigEntry(name: "恢复证书验证")] private readonly static bool restoreCertificateValidation = true;
 
     [EnableIf(nameof(restoreCertificateValidation))]
     [HarmonyPostfix]
@@ -96,7 +96,7 @@ public class Common
         ServicePointManager.ServerCertificateValidationCallback = null;
     }
 
-    [ConfigEntry] private readonly static bool forceNonTarget = true;
+    [ConfigEntry(name: "强制非目标模式")] private readonly static bool forceNonTarget = true;
 
     [EnableIf(nameof(forceNonTarget))]
     [HarmonyPrefix]
@@ -108,7 +108,7 @@ public class Common
         return false;
     }
 
-    [ConfigEntry] private readonly static bool forceNonReporting = true;
+    [ConfigEntry(name: "解决 Reporting 问题")] private readonly static bool forceNonReporting = true;
 
     [EnableIf(nameof(forceNonReporting))]
     [HarmonyPrefix]
@@ -128,7 +128,7 @@ public class Common
         return false;
     }
 
-    [ConfigEntry] private readonly static bool forceIgnoreError = true;
+    [ConfigEntry(name: "强制忽略错误")] private readonly static bool forceIgnoreError = true;
 
     [EnableIf(nameof(forceIgnoreError))]
     [HarmonyPrefix]
@@ -139,7 +139,7 @@ public class Common
         return false;
     }
 
-    [ConfigEntry] private readonly static bool bypassSpecialNumCheck = true;
+    [ConfigEntry(name: "SpecialNum")] private readonly static bool bypassSpecialNumCheck = true;
 
     public static void OnAfterPatch(HarmonyLib.Harmony h)
     {
@@ -182,7 +182,7 @@ public class Common
         return instList.Skip(onceDispIndex);
     }
 
-    [ConfigEntry] private static readonly bool disableDataUploader = true;
+    [ConfigEntry(name: "禁用无用上传")] private static readonly bool disableDataUploader = true;
 
     [EnableIf(nameof(disableDataUploader))]
     [HarmonyPrefix]
@@ -192,9 +192,10 @@ public class Common
         return false;
     }
 
-    [ConfigEntry] private static readonly bool fixGetMusicVersion = true;
+    [ConfigEntry(name: "修复 MusicVersion")] private static readonly bool fixGetMusicVersion = true;
 
     [EnableIf(nameof(fixGetMusicVersion))]
+    [EnableGameVersion(26000)]
     [HarmonyPostfix]
     [HarmonyPatch(typeof(DataManager), nameof(DataManager.GetMusicVersion))]
     private static void GetMusicVersion(int id, ref Manager.MaiStudio.MusicVersionData __result)

--- a/AquaMai.Mods/Fix/FixCheckAuth.cs
+++ b/AquaMai.Mods/Fix/FixCheckAuth.cs
@@ -17,7 +17,7 @@ namespace AquaMai.Mods.Fix;
 [ConfigSection(exampleHidden: true, defaultOn: true)]
 public class FixCheckAuth
 {
-    [ConfigEntry]
+    [ConfigEntry(name: "允许 HTTPS 升级")]
     private static readonly bool allowHttpsUpgrade = true;
 
     private static OperationData operationData;

--- a/AquaMai.Mods/Fix/FixLongMusicRestart.cs
+++ b/AquaMai.Mods/Fix/FixLongMusicRestart.cs
@@ -11,7 +11,8 @@ using Process;
 namespace AquaMai.Mods.Fix;
 
 [EnableGameVersion(25500)]
-[ConfigSection(zh: "修复 Long Music 重开时重复扣除 Track 数",
+[ConfigSection(name: "Long Music 重开修复",
+    zh: "修复 Long Music 重开时重复扣除 Track 数",
     exampleHidden: true, defaultOn: true)]
 public class FixLongMusicRestart
 {

--- a/AquaMai.Mods/GameSettings/CreditConfig.cs
+++ b/AquaMai.Mods/GameSettings/CreditConfig.cs
@@ -8,16 +8,19 @@ using MelonLoader;
 namespace AquaMai.Mods.GameSettings;
 
 [ConfigSection(
+    name: "点数设置",
     en: "Set the game to Paid Play (lock credits) or Free Play.",
     zh: "设置游戏为付费游玩（锁定可用点数）或免费游玩")]
 public class CreditConfig
 {
     [ConfigEntry(
+        name: "免费游玩",
         en: "Set to Free Play (set to false for Paid Play).",
         zh: "是否免费游玩（设为 false 时为付费游玩）")]
     private static readonly bool isFreePlay = true;
 
     [ConfigEntry(
+        name: "免费时购票",
         en: "Allow purchasing paid feature tickets in Free Play mode.",
         zh: "可以在免费游玩时购买付费功能票")]
     private static readonly bool allowTicketInFreePlay = false;
@@ -41,6 +44,7 @@ public class CreditConfig
     }
 
     [ConfigEntry(
+        name: "锁定点数",
         en: "Lock credits amount (only valid in Paid Play). Set to 0 to disable.",
         zh: "锁定可用点数数量（仅在付费游玩时有效），设为 0 以禁用")]
     private static readonly uint lockCredits = 24u;

--- a/AquaMai.Mods/GameSettings/ForceAsServer.cs
+++ b/AquaMai.Mods/GameSettings/ForceAsServer.cs
@@ -5,6 +5,7 @@ using HarmonyLib;
 namespace AquaMai.Mods.GameSettings;
 
 [ConfigSection(
+    name: "强制为服务器",
     en: "If you want to configure in-shop party-link, you should turn this off.",
     zh: "如果要配置店内招募的话，应该要把这个关闭",
     defaultOn: true)]

--- a/AquaMai.Mods/GameSettings/JudgeAdjust.cs
+++ b/AquaMai.Mods/GameSettings/JudgeAdjust.cs
@@ -7,21 +7,23 @@ using Manager.UserDatas;
 namespace AquaMai.Mods.GameSettings;
 
 [ConfigSection(
+    name: "判定调整",
     en: "Globally adjust A/B judgment (unit same as in-game options) or increase touch delay.",
     zh: "全局调整 A/B 判（单位和游戏里一样）或增加触摸延迟")]
 public class JudgeAdjust
 {
     [ConfigEntry(
-        en: "Adjust A judgment.",
-        zh: "调整 A 判")]
+        name: "A判",
+        en: "Adjust A judgment.")]
     private static readonly double a = 0;
 
     [ConfigEntry(
-        en: "Adjust B judgment.",
-        zh: "调整 B 判")]
+        name: "B判",
+        en: "Adjust B judgment.")]
     private static readonly double b = 0;
 
     [ConfigEntry(
+        name: "触摸延迟",
         en: "Increase touch delay.",
         zh: "增加触摸延迟（不建议使用）")]
     private static readonly uint touchDelay = 0;

--- a/AquaMai.Mods/GameSettings/TouchSensitivity.cs
+++ b/AquaMai.Mods/GameSettings/TouchSensitivity.cs
@@ -9,6 +9,7 @@ using MelonLoader;
 namespace AquaMai.Mods.GameSettings;
 
 [ConfigSection(
+    name: "触摸灵敏度",
     en: """
         Use custom touch sensitivity.
         When enabled, the settings in Test mode will not take effect.

--- a/AquaMai.Mods/GameSystem/AddPlayCountWhenQuickRetry.cs
+++ b/AquaMai.Mods/GameSystem/AddPlayCountWhenQuickRetry.cs
@@ -10,6 +10,7 @@ using MelonLoader;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "重开计次",
     defaultOn: true,
     en: "Add play count when quick retry (regardless of trigger type).",
     zh: "在一键重开（无论何种触发方式）时，增加当前谱面的游玩次数")]

--- a/AquaMai.Mods/GameSystem/AdxHidInput.cs
+++ b/AquaMai.Mods/GameSystem/AdxHidInput.cs
@@ -13,6 +13,7 @@ using UnityEngine;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "ADX HID 输入",
     en: "Input using ADX HID firmware (do not enable if you are not using ADX's HID firmware, be sure to delete the existing HID related DLL when enabled)",
     zh: "使用 ADX HID 固件的自定义输入（如果你没有使用 ADX 的 HID 固件，请不要启用。启用时请务必删除现有 HID 相关 DLL）")]
 public class AdxHidInput
@@ -66,16 +67,16 @@ public class AdxHidInput
         }
     }
 
-    [ConfigEntry(zh: "按钮 1（向上的三角键）")]
+    [ConfigEntry(name: "按钮 1（向上的三角键）")]
     private static readonly AdxKeyMap button1 = AdxKeyMap.Select1P;
 
-    [ConfigEntry(zh: "按钮 2（三角键中间的圆形按键）")]
+    [ConfigEntry(name: "按钮 2（三角键中间的圆形按键）")]
     private static readonly AdxKeyMap button2 = AdxKeyMap.Service;
 
-    [ConfigEntry(zh: "按钮 3（向下的三角键）")]
+    [ConfigEntry(name: "按钮 3（向下的三角键）")]
     private static readonly AdxKeyMap button3 = AdxKeyMap.Select2P;
 
-    [ConfigEntry(zh: "按钮 4（最下方的圆形按键）")]
+    [ConfigEntry(name: "按钮 4（最下方的圆形按键）")]
     private static readonly AdxKeyMap button4 = AdxKeyMap.Test;
 
     private static bool GetPushedByButton(int playerNo, InputId inputId)

--- a/AquaMai.Mods/GameSystem/Assets/Fonts.cs
+++ b/AquaMai.Mods/GameSystem/Assets/Fonts.cs
@@ -11,25 +11,27 @@ using UnityEngine.TextCore.LowLevel;
 namespace AquaMai.Mods.GameSystem.Assets;
 
 [ConfigSection(
+    name: "自定义字体",
     en: "Use custom font(s) as fallback or fully replace the original game font.",
     zh: "使用自定义字体作为回退（解决中文字形缺失问题），或完全替换游戏原字体",
     defaultOn: true)]
 public class Fonts
 {
     [ConfigEntry(
+        name: "字体路径",
         en: """
             Font path(s).
             Use semicolon to separate multiple paths for a fallback chain.
             Microsoft YaHei Bold by default.
             """,
         zh: """
-            字体路径
             使用分号分隔多个路径以构成 Fallback 链
             默认为微软雅黑 Bold
             """)]
     private static readonly string paths = "%SYSTEMROOT%/Fonts/msyhbd.ttc";
 
     [ConfigEntry(
+        name: "作为回退字体",
         en: "Add custom font(s) as fallback, use original game font when possible.",
         zh: "将自定义字体作为游戏原字体的回退，尽可能使用游戏原字体")]
     private static readonly bool addAsFallback = true;

--- a/AquaMai.Mods/GameSystem/Assets/LoadAssetBundleWithoutManifest.cs
+++ b/AquaMai.Mods/GameSystem/Assets/LoadAssetBundleWithoutManifest.cs
@@ -9,6 +9,7 @@ using AquaMai.Config.Attributes;
 namespace AquaMai.Mods.GameSystem.Assets;
 
 [ConfigSection(
+    name: "无视 Manifest",
     en: "Load all existing \".ab\" image resources regardless of the AssetBundleImages manifest.",
     zh: """
         加载所有存在的 .ab 图片资源（无视 AssetBundleImages.manifest）

--- a/AquaMai.Mods/GameSystem/Assets/LoadLocalImages.cs
+++ b/AquaMai.Mods/GameSystem/Assets/LoadLocalImages.cs
@@ -15,12 +15,13 @@ using AquaMai.Core.Helpers;
 namespace AquaMai.Mods.GameSystem.Assets;
 
 [ConfigSection(
+    name: "直读图片",
     en: "Load asset images from the configured directory (for self-made charts).",
     zh: "从指定目录下加载资源图片（自制谱用）",
     defaultOn: true)]
 public class LoadLocalImages
 {
-    [ConfigEntry]
+    [ConfigEntry(name: "图片路径")]
     private static readonly string imageAssetsDir = "LocalAssets";
 
     private static readonly string[] imageExts = [".jpg", ".png", ".jpeg"];

--- a/AquaMai.Mods/GameSystem/Assets/MovieLoader.cs
+++ b/AquaMai.Mods/GameSystem/Assets/MovieLoader.cs
@@ -16,30 +16,35 @@ using UnityEngine.Video;
 namespace AquaMai.Mods.GameSystem.Assets;
 
 [ConfigSection(
+    name: "直读 PV",
     en: "Custom Play Song Background\nPriority: game source PV > local mp4 PV > jacket",
     zh: "自定义歌曲游玩界面背景\n优先级: 首先读游戏自带 PV, 然后读本地 mp4 格式 PV, 最后读封面",
     defaultOn: true)]
 public class MovieLoader
 {
     [ConfigEntry(
+        name: "游戏自带 PV",
         en: "Load Movie from game source",
         zh: "加载游戏自带的 PV")]
     private static bool loadSourceMovie = true;
 
 
     [ConfigEntry(
+        name: "本地 MP4",
         en: "Load Movie from LocalAssets mp4 files",
         zh: "从 LocalAssets 中加载 MP4 文件作为 PV")]
     private static bool loadMp4Movie = true;
 
 
     [ConfigEntry(
+        name: "MP4 路径",
         en: "MP4 files directory",
         zh: "加载 MP4 文件的路径")]
     private static readonly string movieAssetsDir = "LocalAssets";
 
 
     [ConfigEntry(
+        name: "封面作为背景",
         en: "Use jacket as movie\nUse together with `LoadLocalImages`.",
         zh: "用封面作为背景 PV\n请和 `LoadLocalImages` 一起用")]
     private static bool jacketAsMovie = true;

--- a/AquaMai.Mods/GameSystem/CustomCameraId.cs
+++ b/AquaMai.Mods/GameSystem/CustomCameraId.cs
@@ -13,6 +13,7 @@ using AquaMai.Core.Resources;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "自定义摄像头",
     en: """
         Use custom CameraId rather than the default ones.
         If enabled, you can customize the game to use the specified camera.
@@ -24,28 +25,29 @@ namespace AquaMai.Mods.GameSystem;
 public class CustomCameraId
 {
     [ConfigEntry(
+        name: "打印摄像头列表",
         en: "Print the camera list to the log when starting, can be used as a basis for modification.",
         zh: "启动时打印摄像头列表到日志中，可以作为修改的依据")]
     public static bool printCameraList;
 
     [ConfigEntry(
         en: "DX Pass 1P.",
-        zh: "DX Pass 1P")]
+        name: "DX Pass 1P")]
     public static int leftQrCamera;
 
     [ConfigEntry(
         en: "DX Pass 2P.",
-        zh: "DX Pass 2P")]
+        name: "DX Pass 2P")]
     public static int rightQrCamera;
 
     [ConfigEntry(
         en: "Player Camera.",
-        zh: "玩家摄像头")]
+        name: "玩家摄像头")]
     public static int photoCamera;
 
     [ConfigEntry(
         en: "WeChat QRCode Camera.",
-        zh: "二维码扫描摄像头")]
+        name: "二维码扫描器")]
     public static int chimeCamera;
 
     private static readonly Dictionary<string, string> cameraTypeMap = new()

--- a/AquaMai.Mods/GameSystem/DisableTimeout.cs
+++ b/AquaMai.Mods/GameSystem/DisableTimeout.cs
@@ -14,23 +14,26 @@ using UnityEngine.Playables;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "去除倒计时",
     en: "Disable timers (hidden and set to 65535 seconds).",
     zh: "去除并隐藏游戏中的倒计时")]
 public class DisableTimeout
 {
     [ConfigEntry(
+        name: "游戏开始倒计时",
         en: "Disable game start timer.",
         zh: "也移除刷卡和选择模式界面的倒计时")]
     private static readonly bool inGameStart = true;
 
     [ConfigEntry(
+        name: "照片编辑倒计时",
         en: "Disable timer in PhotoEditProcess, not recommended.",
         zh: "也移除 可以看一看游戏成绩哦 界面的倒计时，不推荐启用，会导致无法点击上传照片按钮")]
     private static readonly bool inPhotoEditProcess = false;
 
     [ConfigEntry(
-        en: "Hide the timer display.",
-        zh: "隐藏计时器")]
+        name: "隐藏计时器",
+        en: "Hide the timer display.")]
     private static readonly bool hideTimer = true;
 
     private static bool ShouldNotEnable()

--- a/AquaMai.Mods/GameSystem/ExteraMouseInput.cs
+++ b/AquaMai.Mods/GameSystem/ExteraMouseInput.cs
@@ -11,17 +11,20 @@ using UnityEngine.UI;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "触屏优化",
     defaultOn: true,
     en: "Enable touch input with radius for a more realistic touchscreen experience.",
     zh: "启用触摸输入和半径，以获得更真实的触摸屏体验")]
 public partial class ExteraMouseInput
 {
     [ConfigEntry(
+        name: "触摸半径",
         en: "Touch area radius size. Adjust according to the size of your finger, you can test in Test Mode.",
         zh: "触摸区域半径大小。请根据手指大小调整，可以去 Test 中测试")]
     public readonly static float radius = 25;
 
     [ConfigEntry(
+        name: "显示触摸点",
         en: "Display touch points (only for touch input).",
         zh: "显示触摸点（仅限触屏输入）")]
     public readonly static bool displayArea = false;

--- a/AquaMai.Mods/GameSystem/KeyMap.cs
+++ b/AquaMai.Mods/GameSystem/KeyMap.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "按键映射",
     en: """
         Enable or disable IO4 and DebugInput. Configure the key mapping for DebugInput.
         DebugInput works independently of IO4 (IO4-compatible board / segatools IO4 emulation).
@@ -23,6 +24,7 @@ namespace AquaMai.Mods.GameSystem;
 public class KeyMap
 {
     [ConfigEntry(
+        name: "禁用 IO4",
         en: """
             Disable IO4 (IO4-compatible board / segatools IO4 emulation) input.
             With IO4 input disabled, your IO4-compatible board or segatools IO4 emulation is ignored.
@@ -34,6 +36,7 @@ public class KeyMap
     private static readonly bool disableIO4 = false;
 
     [ConfigEntry(
+        name: "禁用 DebugInput",
         en: """
             Disable DebugInput. The key mapping below will not work.
             With DebugInput disabled, you'll need a IO4-compatible board, segatools IO4 emulation or other custom input solutions to play.
@@ -47,6 +50,7 @@ public class KeyMap
     public static readonly bool disableDebugInput = false; // Implemented in AquaMai.Mods/Fix/Common.cs
 
     [ConfigEntry(
+        name: "禁用调试快捷键",
         en: """
             Disable DebugFeature Polyfill hotkeys, like Enter to pause, Left/Right to seek, etc.
             """,

--- a/AquaMai.Mods/GameSystem/OptionLoadFix.cs
+++ b/AquaMai.Mods/GameSystem/OptionLoadFix.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "Opt 加载修复",
     en: "When loading Opt in StreamingAssets, not only load those starting with A, but also those starting with the letter corresponding to the version",
     zh: "在 StreamingAssets 加载 Opt 时，不仅加载 A 开头的，也加载版本对应字母开头的",
     defaultOn: true)]

--- a/AquaMai.Mods/GameSystem/QuickRetry.cs
+++ b/AquaMai.Mods/GameSystem/QuickRetry.cs
@@ -6,12 +6,14 @@ using Manager;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "快速重开",
     en: "Hold the bottom four buttons (3456) for quick retry (like in Freedom Mode, default non-utage only).",
     zh: "按住下方四个按钮（3456）快速重开本局游戏（像在 Freedom Mode 中一样，默认仅对非宴谱有效）")]
 [EnableGameVersion(23000)]
 public class QuickRetry
 {
     [ConfigEntry(
+        name: "宴谱启用",
         en: "Force enable in Utage.",
         zh: "在宴谱中强制启用")]
     private static readonly bool enableInUtage = false;

--- a/AquaMai.Mods/GameSystem/RemoveEncryption.cs
+++ b/AquaMai.Mods/GameSystem/RemoveEncryption.cs
@@ -9,6 +9,7 @@ using Net.Packet;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "移除加密",
     en: """
         If you are using an unmodified client, requests to the server will be encrypted by default, but requests to the private server should not be encrypted.
         With this option enabled, the connection will not be encrypted, and the suffix added by different versions of the client to the API names are also removed.

--- a/AquaMai.Mods/GameSystem/SinglePlayer.cs
+++ b/AquaMai.Mods/GameSystem/SinglePlayer.cs
@@ -23,6 +23,7 @@ namespace AquaMai.Mods.GameSystem;
 // Hides the 2p (right hand side) UI.
 // Note: this is not my original work. I simply interpreted the code and rewrote it as a mod.
 [ConfigSection(
+    name: "单人模式",
     en: """
         Single player: Show 1P only, at the center of the screen.
         """,
@@ -33,6 +34,7 @@ public partial class SinglePlayer
 {
 
     [ConfigEntry(
+        name: "隐藏副屏",
         en: "Only show the main area, without the sub-monitor.",
         zh: "只显示主区域，不显示副屏")]
     public static bool HideSubMonitor = false;
@@ -64,6 +66,7 @@ public partial class SinglePlayer
     }
 
     [ConfigEntry(
+        name: "自动跳过倒计时",
         en: "Automatically skip the countdown when logging in with a card in single-player mode.",
         zh: "单人模式下刷卡登录直接进入下一个界面，无需跳过倒计时")]
     public static bool autoSkip = false;
@@ -104,6 +107,7 @@ public partial class SinglePlayer
     }
 
     [ConfigEntry(
+        name: "修复烟花效果",
         en: "Fix hanabi effect under single-player mode (disabled automatically if HideHanabi is enabled).",
         zh: "修复单人模式下的烟花效果（如果启用了 HideHanabi，则会自动禁用）")]
     public static bool fixHanabi = true;

--- a/AquaMai.Mods/GameSystem/SkipBoardNoCheck.cs
+++ b/AquaMai.Mods/GameSystem/SkipBoardNoCheck.cs
@@ -12,6 +12,7 @@ using UnityEngine;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "旧框灯板支持",
     en: "Skip BoardNo check to use the old cab light board 837-15070-02",
     zh: "跳过 BoardNo 检查以使用 837-15070-02（旧框灯板）")]
 public class SkipBoardNoCheck

--- a/AquaMai.Mods/GameSystem/Sound.cs
+++ b/AquaMai.Mods/GameSystem/Sound.cs
@@ -6,23 +6,24 @@ using System;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "音频输出设置",
     zh: "音频独占与八声道设置",
     en: "Audio Exclusive and 8-Channel Settings")]
 public static class Sound
 {
     [ConfigEntry(
-        zh: "是否启用音频独占",
+        name: "音频独占",
         en: "Enable Audio Exclusive")]
     private readonly static bool enableExclusive = false;
 
     [ConfigEntry(
-        zh: "是否启用八声道",
+        name: "八声道",
         en: "Enable 8-Channel")]
     private readonly static bool enable8Channel = false;
 
     [ConfigEntry(
-        en: "Music Volume.",
-        zh: "乐曲音量")]
+        name: "乐曲音量",
+        en: "Music Volume.")]
     private readonly static float musicVolume = 1.0f;
 
     private static CriAtomUserExtension.AudioClientShareMode AudioShareMode => enableExclusive ? CriAtomUserExtension.AudioClientShareMode.Exclusive : CriAtomUserExtension.AudioClientShareMode.Shared;

--- a/AquaMai.Mods/GameSystem/TestProof.cs
+++ b/AquaMai.Mods/GameSystem/TestProof.cs
@@ -15,6 +15,7 @@ using Manager;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "测试键长按",
     en: """
         When enabled, test button must be long pressed to enter game test mode.
         When test button is bound to other features, this option is enabled automatically.
@@ -52,6 +53,7 @@ public class TestProof
     }
 
     [ConfigEntry(
+        name: "测试模式按键",
         en: "Change it to a value other than Test to enable long pressing of a specific key to enter the game test mode, so that the Test key can be fully used to implement custom functions",
         zh: "修改为 Test 以外的值来实现长按特定的键进入游戏测试模式，这样 Test 键就可以完全用来实现自定义功能了")]
     private static readonly KeyCodeOrName testKey = KeyCodeOrName.Test;

--- a/AquaMai.Mods/GameSystem/TouchPanelBaudRate.cs
+++ b/AquaMai.Mods/GameSystem/TouchPanelBaudRate.cs
@@ -5,6 +5,7 @@ using IO;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "触摸屏波特率",
     en: """
         Adjust the baud rate of the touch screen serial port, default value is 9600.
         Requires hardware support. If you are unsure, don't use it.
@@ -16,8 +17,8 @@ namespace AquaMai.Mods.GameSystem;
 public class TouchPanelBaudRate
 {
     [ConfigEntry(
-        en: "Baud rate.",
-        zh: "波特率")]
+        name: "波特率",
+        en: "Baud rate.")]
     private static readonly int baudRate = 9600;
 
     [HarmonyPatch(typeof(NewTouchPanel), "Open")]

--- a/AquaMai.Mods/GameSystem/TouchPanelPort.cs
+++ b/AquaMai.Mods/GameSystem/TouchPanelPort.cs
@@ -5,6 +5,7 @@ using IO;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "触摸屏串口",
     en: """
         Adjust the port of the touch screen serial port, default value is COM3 COM4.
         Requires configuration by Device Manager. If you are unsure, don't use it.

--- a/AquaMai.Mods/GameSystem/TouchToButtonInput.cs
+++ b/AquaMai.Mods/GameSystem/TouchToButtonInput.cs
@@ -8,6 +8,7 @@ using static Manager.InputManager;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "触摸转按键",
     en: "Map touch actions to buttons.",
     zh: "映射触摸操作至实体按键")]
 public class TouchToButtonInput

--- a/AquaMai.Mods/GameSystem/Unlock.cs
+++ b/AquaMai.Mods/GameSystem/Unlock.cs
@@ -18,6 +18,7 @@ using System.Runtime.CompilerServices;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "全解",
     en: """
         Unlock normally locked (including normally non-unlockable) game content.
         Anything unlocked (except the characters you leveled-up) by this mod will not be uploaded your account.
@@ -36,6 +37,7 @@ public class Unlock
     }
 
     [ConfigEntry(
+        name: "区域",
         en: "Unlock maps that are not in this version.",
         zh: "解锁游戏里所有的区域，包括非当前版本的（并不会帮你跑完）")]
     private static readonly bool maps = true;
@@ -79,6 +81,7 @@ public class Unlock
     }
 
     [ConfigEntry(
+        name: "乐曲",
         en: "Unlock all songs, and skip the Master/ReMaster unlock screen (still save the unlock status).",
         zh: "解锁所有乐曲，并跳过紫/白解锁画面（会正常保存解锁状态）")]
     private static readonly bool songs = true;
@@ -190,6 +193,7 @@ public class Unlock
     }
 
     [ConfigEntry(
+        name: "跑图券",
         en: "Unlock normally event-only tickets.",
         zh: "解锁游戏里所有可能的跑图券")]
     private static readonly bool tickets = false;
@@ -228,6 +232,7 @@ public class Unlock
     }
 
     [ConfigEntry(
+        name: "段位",
         en: "Unlock all course-mode courses (no need to reach 10th dan to play \"real\" dan).",
         zh: "解锁所有段位模式的段位（不需要十段就可以打真段位）")]
     private static readonly bool courses = false;
@@ -264,6 +269,7 @@ public class Unlock
     }
 
     [ConfigEntry(
+        name: "宴会场",
         en: "Unlock Utage without the need of DXRating 10000.",
         zh: "不需要万分也可以进宴会场")]
     private static readonly bool utage = true;
@@ -298,42 +304,43 @@ public class Unlock
     ];
 
     [ConfigEntry(
-        en: "Unlock all titles.",
-        zh: "解锁所有称号"
+        name: "称号",
+        en: "Unlock all titles."
     )]
     private static readonly bool titles = false;
 
     [ConfigEntry(
-        en: "Unlock all icons.",
-        zh: "解锁所有头像"
+        name: "头像",
+        en: "Unlock all icons."
     )]
     private static readonly bool icons = false;
 
     [ConfigEntry(
-        en: "Unlock all plates.",
-        zh: "解锁所有姓名框"
+        name: "姓名框",
+        en: "Unlock all plates."
     )]
     private static readonly bool plates = false;
 
     [ConfigEntry(
-        en: "Unlock all frames.",
-        zh: "解锁所有背景"
+        name: "背景",
+        en: "Unlock all frames."
     )]
     private static readonly bool frames = false;
 
     [ConfigEntry(
-        en: "Unlock all partners.",
-        zh: "解锁所有搭档"
+        name: "搭档",
+        en: "Unlock all partners."
     )]
     private static readonly bool partners = false;
 
     [ConfigEntry(
-        en: "Enable all events.",
-        zh: "启用所有的 “Events”"
+        name: "Events",
+        en: "Enable all events."
     )]
     private static readonly bool events = false;
 
     [ConfigEntry(
+        name: "Event 黑名单",
         en: "Do not unlock the following events. Leave it enabled if you don't know what this is.",
         zh: "不解锁以下 Event。如果你不知道这是什么，请勿修改",
         hideWhenDefault: true
@@ -480,8 +487,8 @@ public class Unlock
     }
 
     [ConfigEntry(
-        en: "Unlock all characters.",
-        zh: "解锁所有旅行伙伴"
+        name: "旅行伙伴",
+        en: "Unlock all characters."
     )]
     private static readonly bool characters = false;
 

--- a/AquaMai.Mods/GameSystem/Window.cs
+++ b/AquaMai.Mods/GameSystem/Window.cs
@@ -7,21 +7,24 @@ using UnityEngine;
 namespace AquaMai.Mods.GameSystem;
 
 [ConfigSection(
+    name: "图形设置",
     en: "Resolution Settings / Windowed Mode.",
     zh: "分辨率设置 / 窗口化")]
 public class Window
 {
     [ConfigEntry(
+        name: "窗口模式",
         en: "Window the game.",
         zh: "窗口化游戏")]
     private static readonly bool windowed = false;
 
     [ConfigEntry(
-        en: "Borderless window.",
-        zh: "无边框窗口")]
+        name: "无边框",
+        en: "Borderless window.")]
     private static readonly bool borderless = false;
 
     [ConfigEntry(
+        name: "宽度",
         en: """
             Window width (and height) for windowed mode, rendering resolution for fullscreen mode.
             If set to 0, windowed mode will remember the user-set size, fullscreen mode will use the current display resolution.
@@ -30,13 +33,13 @@ public class Window
         zh: """
             宽度（和高度）窗口化时为游戏窗口大小，全屏时为渲染分辨率
             如果设为 0，窗口化将记住用户设定的大小，全屏时将使用当前显示器分辨率
-            全屏时如果显示大小不正确，请改成屏幕的分辨率
+            全屏时如果显示大小不正确，请改成屏幕的分辨率（如 2160x3840）
             """)]
     private static readonly int width = 0;
 
     [ConfigEntry(
-        en: "Height, as above.",
-        zh: "高度，同上")]
+        name: "高度",
+        en: "Height, as above.")]
     private static readonly int height = 0;
 
     private const int GWL_STYLE = -16;

--- a/AquaMai.Mods/General.cs
+++ b/AquaMai.Mods/General.cs
@@ -5,12 +5,13 @@ namespace AquaMai.Mods;
 // This class is for settings only. Don't patch anything here.
 
 [ConfigSection(
+    name: "AquaMai 的通用设置",
     en: "AquaMai's general settings.",
-    zh: "AquaMai 的通用设置",
     alwaysEnabled: true)]
 public class General
 {
     [ConfigEntry(
+        name: "AquaMai 语言",
         en: """
             Language for mod UI (en and zh supported).
             If empty, the system language will be used.

--- a/AquaMai.Mods/Tweaks/IgnoreAimeServerError.cs
+++ b/AquaMai.Mods/Tweaks/IgnoreAimeServerError.cs
@@ -5,6 +5,7 @@ using Manager;
 namespace AquaMai.Mods.Tweaks;
 
 [ConfigSection(
+    name: "忽略 Aime 错误",
     en: "Prevent gray network caused by mistakenly thinking it's an AimeDB server issue.",
     zh: "防止因错误认为 AimeDB 服务器问题引起的灰网，建议开启",
     defaultOn: true)]

--- a/AquaMai.Mods/Tweaks/LockFrameRate.cs
+++ b/AquaMai.Mods/Tweaks/LockFrameRate.cs
@@ -4,17 +4,19 @@ using UnityEngine;
 namespace AquaMai.Mods.Tweaks;
 
 [ConfigSection(
+    name: "锁定帧率",
     en: """
         Force the frame rate limit to 60 FPS and disable vSync.
-        Do not use if your game has no issues.
+        Do not use if your game has no issues. Suggest to set the refresh rate of your display instead.
         """,
     zh: """
         强制设置帧率上限为 60 帧并关闭垂直同步
-        如果你的游戏没有问题，请不要使用
+        如果你的游戏没有问题，请不要使用。建议直接设置显示器的刷新率
         """)]
 public class LockFrameRate
 {
     [ConfigEntry(
+        name: "目标帧率",
         zh: "目标帧率，不建议修改。除非你知道你在做什么")]
     public static readonly int targetFrameRate = 60;
 

--- a/AquaMai.Mods/Tweaks/ResetTouch.cs
+++ b/AquaMai.Mods/Tweaks/ResetTouch.cs
@@ -15,10 +15,10 @@ namespace AquaMai.Mods.Tweaks;
     zh: "重置触摸面板")]
 public class ResetTouch
 {
-    [ConfigEntry(en: "Reset touch panel after playing track.", zh: "玩完一首歌自动重置")]
+    [ConfigEntry(en: "Reset touch panel after playing track.", name: "玩完一首歌自动重置")]
     private static bool afterTrack = false;
 
-    [ConfigEntry(en: "Reset manually.", zh: "按键重置")]
+    [ConfigEntry(en: "Reset manually.", name: "重置按键")]
     public static readonly KeyCodeOrName key = KeyCodeOrName.None;
 
     [ConfigEntry] private static readonly bool longPress = false;

--- a/AquaMai.Mods/Tweaks/SkipUserVersionCheck.cs
+++ b/AquaMai.Mods/Tweaks/SkipUserVersionCheck.cs
@@ -5,6 +5,7 @@ using Process.Entry.State;
 namespace AquaMai.Mods.Tweaks;
 
 [ConfigSection(
+    name: "跳过版本检查",
     en: "Allow login with higher data version.",
     zh: """
         原先如果你的账号版本比当前游戏设定的版本高的话，就会不能登录

--- a/AquaMai.Mods/Tweaks/TimeSaving/EntryToMusicSelection.cs
+++ b/AquaMai.Mods/Tweaks/TimeSaving/EntryToMusicSelection.cs
@@ -16,11 +16,12 @@ using EnableConditionOperator = AquaMai.Core.Attributes.EnableConditionOperator;
 namespace AquaMai.Mods.Tweaks.TimeSaving;
 
 [ConfigSection(
+    name: "登录后直接选歌",
     en: "Directly enter the song selection screen after login.",
     zh: "登录完成后直接进入选歌界面")]
 public class EntryToMusicSelection
 {
-    [ConfigEntry(zh: "仅在游客模式启用", en: "Enable only in Guest Mode")]
+    [ConfigEntry(name: "仅游客模式", zh: "仅在游客模式启用", en: "Enable only in Guest Mode")]
     private static readonly bool enableOnlyInGuestMode = false;
     /*
      * Highly experimental, may well break some stuff

--- a/AquaMai.Mods/Tweaks/TimeSaving/ExitToSave.cs
+++ b/AquaMai.Mods/Tweaks/TimeSaving/ExitToSave.cs
@@ -5,6 +5,7 @@ using Process;
 namespace AquaMai.Mods.Tweaks.TimeSaving;
 
 [ConfigSection(
+    name: "游戏结束直接登出",
     en: "Skip uploading photos and collectibles after the game ends and log out directly.",
     zh: "游戏结束后跳过上传照片和收藏品直接登出")]
 public class ExitToSave

--- a/AquaMai.Mods/Tweaks/TimeSaving/IWontTapOrSlideVigorously.cs
+++ b/AquaMai.Mods/Tweaks/TimeSaving/IWontTapOrSlideVigorously.cs
@@ -5,6 +5,7 @@ using Monitor;
 namespace AquaMai.Mods.Tweaks.TimeSaving;
 
 [ConfigSection(
+    name: "跳过拍打警告",
     en: "Skip the \"Do not tap or slide vigorously\" screen, immediately proceed to the next screen once data is loaded.",
     zh: "跳过“不要大力拍打或滑动哦”这个界面，数据一旦加载完就立马进入下一个界面")]
 public class IWontTapOrSlideVigorously

--- a/AquaMai.Mods/Tweaks/TimeSaving/SkipEventInfo.cs
+++ b/AquaMai.Mods/Tweaks/TimeSaving/SkipEventInfo.cs
@@ -7,6 +7,7 @@ using Process.Information;
 namespace AquaMai.Mods.Tweaks.TimeSaving;
 
 [ConfigSection(
+    name: "跳过活动提示",
     en: "Skip possible prompts like \"New area discovered\", \"New songs added\", \"There are events\" during game login/registration.",
     zh: "跳过登录 / 注册游戏时候可能的 “发现了新的区域哟” “乐曲增加” “有活动哟” 之类的提示")]
 public class SkipEventInfo

--- a/AquaMai.Mods/Tweaks/TimeSaving/SkipGoodbyeScreen.cs
+++ b/AquaMai.Mods/Tweaks/TimeSaving/SkipGoodbyeScreen.cs
@@ -6,6 +6,7 @@ using Process;
 namespace AquaMai.Mods.Tweaks.TimeSaving;
 
 [ConfigSection(
+    name: "跳过再见界面",
     en: "Skip the \"Goodbye\" screen at the end of the game.",
     zh: "跳过游戏结束的「再见」界面")]
 public class SkipGoodbyeScreen

--- a/AquaMai.Mods/Tweaks/TimeSaving/SkipStartupDelays.cs
+++ b/AquaMai.Mods/Tweaks/TimeSaving/SkipStartupDelays.cs
@@ -6,6 +6,7 @@ using Process;
 namespace AquaMai.Mods.Tweaks.TimeSaving;
 
 [ConfigSection(
+    name: "跳过启动延迟",
     en: "Skip useless 2s delays to speed up the game boot process.",
     zh: """
         在自检界面，每个屏幕结束的时候都会等两秒才进入下一个屏幕，很浪费时间

--- a/AquaMai.Mods/Tweaks/TimeSaving/SkipStartupWarning.cs
+++ b/AquaMai.Mods/Tweaks/TimeSaving/SkipStartupWarning.cs
@@ -5,6 +5,7 @@ using Monitor;
 namespace AquaMai.Mods.Tweaks.TimeSaving;
 
 [ConfigSection(
+    name: "跳过启动警告",
     en: "Skip SDEZ's warning screen and logo shown after the POST sequence.",
     zh: "跳过 SDEZ 启动时的 WARNING 界面",
     defaultOn: true)]

--- a/AquaMai.Mods/Tweaks/TimeSaving/SkipTrackStart.cs
+++ b/AquaMai.Mods/Tweaks/TimeSaving/SkipTrackStart.cs
@@ -6,6 +6,7 @@ using Process;
 namespace AquaMai.Mods.Tweaks.TimeSaving;
 
 [ConfigSection(
+    name: "跳过乐曲开始",
     en: "Skip TrackStart screen.",
     zh: "跳过乐曲开始界面")]
 public class SkipTrackStart

--- a/AquaMai.Mods/UX/DisableLightOutGame.cs
+++ b/AquaMai.Mods/UX/DisableLightOutGame.cs
@@ -9,6 +9,7 @@ using Process;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
+    name: "闲置时关闭灯光",
     en: "Disable button LED when not playing",
     zh: """
         在游戏闲置时关闭外键和框体的灯光
@@ -20,9 +21,6 @@ public static class DisableLightOutGame
     [HarmonyPatch(typeof(Bd15070_4IF), nameof(Bd15070_4IF.SetColorFetAutoFade))]
     public static bool SetColorFetAutoFadePrefix()
     {
-#if DEBUG
-        MelonLogger.Msg("[DisableLightOutGame] 拦截 Bd15070_4IF.SetColorFetAutoFade");
-#endif
         return false;
     }
 
@@ -30,9 +28,6 @@ public static class DisableLightOutGame
     [HarmonyPatch(typeof(AdvDemoMonitor), "BeatUpdate")]
     public static bool BeatUpdate()
     {
-#if DEBUG
-        MelonLogger.Msg("[DisableLightOutGame] 拦截 AdvDemoMonitor.BeatUpdate");
-#endif
         return false;
     }
 

--- a/AquaMai.Mods/UX/DontRuinMyAccount.cs
+++ b/AquaMai.Mods/UX/DontRuinMyAccount.cs
@@ -17,7 +17,7 @@ using UnityEngine;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
-    zh: "AutoPlay 时不保存成绩",
+    name: "AutoPlay 时不保存成绩",
     en: "Do not save scores when AutoPlay is used",
     defaultOn: true)]
 // 收编自 https://github.com/Starrah/DontRuinMyAccount/blob/master/Core.cs

--- a/AquaMai.Mods/UX/FestaControl.cs
+++ b/AquaMai.Mods/UX/FestaControl.cs
@@ -6,12 +6,14 @@ using Manager;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
+    name: "Festa 开关",
     zh: "控制 “Festa” 模式 UI 的显示。如不开启，则不会更改设置，由 Event 或者服务器控制",
     en: "Control the display of “Festa” mode UI. If not enabled, the settings will not be changed, and Event or server will control it")]
 [EnableGameVersion(26000)]
 public static class FestaControl
 {
     [ConfigEntry(
+        name: "启用 Festa",
         zh: "是否显示 “Festa” 模式 UI",
         en: "Whether to display “Festa” mode UI")]
     public static readonly bool isFesta = false;

--- a/AquaMai.Mods/UX/FixTrackNumDisplay.cs
+++ b/AquaMai.Mods/UX/FixTrackNumDisplay.cs
@@ -10,11 +10,13 @@ using UnityEngine;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
+    name: "两位数曲目修复",
     en: "Make track number in top right corner display two digits",
     zh: "让右上角的当前曲目数字可以显示两位数")]
 public class FixTrackNumDisplay
 {
     [ConfigEntry(
+        name: "显示格式",
         en: "Track number display style: 0=Left-padded (_5), 1=Zero-padded (05), 2=Right-padded (5_)",
         zh: "曲目数字显示格式: 0=左侧补空格(_5), 1=左侧补零(05), 2=右侧补空格(5_)")]
     private static readonly int TrackNumDisplayStyle = 0; // Default 0

--- a/AquaMai.Mods/UX/HardwareAlert.cs
+++ b/AquaMai.Mods/UX/HardwareAlert.cs
@@ -22,45 +22,47 @@ using UnityEngine;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
+    name: "自定义自检警告",
     en: "Custom hardware alert, you can configure to display an error frame upon hardware failure. Toggle the switches below to define the required hardware.",
     zh: "自定义硬件警告，可配置在指定硬件自检失败时阻止游戏启动并显示报错画面，开启下方的错误类型以配置需要关注的错误。")]
 public class HardwareAlert
 {
     [ConfigEntry(
+        name: "原始语言显示",
         en: "If enabled, all the in-game hardware warnings will be displayed in game's original language, like Japanese for SDEZ. If you have used any translation pack, you should disable this setting.",
         zh: "如果启用，所有硬件警告将会使用游戏原本的语言显示，例如 SDEZ 就会用日文显示报错。如果你安装了任何汉化包，你应该关闭这个选项。")]
     private static readonly bool UseOriginalGameLanguage = true;
     [ConfigEntry(
         en: "1P Touch Sensor",
-        zh: "1P 触摸屏")]
+        name: "1P 触摸屏")]
     private static readonly bool TouchSensor_1P = false; // Error 3300, 3301
     [ConfigEntry(
         en: "2P Touch Sensor",
-        zh: "2P 触摸屏")]
+        name: "2P 触摸屏")]
     private static readonly bool TouchSensor_2P = false; // Error 3302, 3303
     [ConfigEntry(
         en: "1P LED",
-        zh: "1P LED")]
+        name: "1P LED")]
     private static readonly bool LED_1P = false; // custom 3400
     [ConfigEntry(
         en: "2P LED",
-        zh: "2P LED")]
+        name: "2P LED")]
     private static readonly bool LED_2P = false; // custom 3401
     [ConfigEntry(
         en: "Player Camera",
-        zh: "玩家摄像机")]
+        name: "玩家摄像机")]
     private static readonly bool PlayerCamera = false;  // 3102
     [ConfigEntry(
         en: "DX Pass 1P",
-        zh: "DX Pass 1P")]
+        name: "DX Pass 1P")]
     private static readonly bool CodeReader_1P = false; // 3101
     [ConfigEntry(
         en: "DX Pass 2P",
-        zh: "DX Pass 2P")]
+        name: "DX Pass 2P")]
     private static readonly bool CodeReader_2P = false; // 3101
     [ConfigEntry(
         en: "WeChat QRCode Camera",
-        zh: "二维码扫描摄像头")]
+        name: "二维码扫描摄像头")]
     public static readonly bool ChimeCamera = false; // 3100
 
     private static readonly List<string> CameraTypeList = ["QRLeft", "QRRight", "Photo", "Chime"];

--- a/AquaMai.Mods/UX/Hide1879.cs
+++ b/AquaMai.Mods/UX/Hide1879.cs
@@ -7,6 +7,7 @@ using Manager;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
+    name: "隐藏乱码曲",
     en: "Hide glitch Xaleid◆scopiX in normal mode",
     zh: "在正常模式中，隐藏乱码曲 Xaleid◆scopiX",
     defaultOn: true

--- a/AquaMai.Mods/UX/HideSelfMadeCharts.cs
+++ b/AquaMai.Mods/UX/HideSelfMadeCharts.cs
@@ -17,11 +17,13 @@ using Util;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
+    name: "自制谱隐藏",
     en: "One key to hide all self-made charts in the music select process. Or hide for some users.",
     zh: "在选曲界面一键隐藏所有自制谱，或对一部分用户进行隐藏")]
 public class HideSelfMadeCharts
 {
     [ConfigEntry(
+        name: "默认隐藏",
         en: "Hide self-made charts by default when login.",
         zh: "登录时默认隐藏自制谱")]
     public static readonly bool defaultHide = false;
@@ -31,14 +33,16 @@ public class HideSelfMadeCharts
         zh: "切换自制谱显示的按键")]
     public static readonly KeyCodeOrName key = KeyCodeOrName.Test;
 
-    [ConfigEntry] public static readonly bool longPress = false;
+    [ConfigEntry(name: "长按")] public static readonly bool longPress = false;
 
     [ConfigEntry(
+        name: "黑名单",
         en: "One user ID per line in the file. Hide self-made charts when these users login.",
         zh: "该文件中每行一个用户 ID，当这些用户登录时隐藏自制谱")]
     private static readonly string selfMadeChartsDenyUsersFile = "LocalAssets/SelfMadeChartsDenyUsers.txt";
 
     [ConfigEntry(
+        name: "白名单",
         en: "One user ID per line in the file. Only show self-made charts when these users login.",
         zh: "该文件中每行一个用户 ID，只有这些用户登录时才显示自制谱")]
     private static readonly string selfMadeChartsWhiteListUsersFile = "LocalAssets/SelfMadeChartsWhiteListUsers.txt";

--- a/AquaMai.Mods/UX/ImmediateSave.cs
+++ b/AquaMai.Mods/UX/ImmediateSave.cs
@@ -24,11 +24,15 @@ using UnityEngine;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
+    name: "打一首存一首",
     en: "Save immediate after playing a song.",
     zh: "打完一首歌的时候立即向服务器保存成绩",
     defaultOn: true)]
 public class ImmediateSave
 {
+    [ConfigEntry(name: "显示保存中提示")]
+    public static readonly bool showTip = true;
+
     [HarmonyPatch]
     public static class RequestUploadUserPlayLogMaybeListData
     {
@@ -73,7 +77,7 @@ public class ImmediateSave
                 continue;
             }
 
-            if (ui == null)
+            if (ui == null && showTip)
             {
                 ui = SharedInstances.GameMainObject.gameObject.AddComponent<SavingUi>();
             }

--- a/AquaMai.Mods/UX/JudgeAccuracyInfo.cs
+++ b/AquaMai.Mods/UX/JudgeAccuracyInfo.cs
@@ -18,6 +18,7 @@ using Object = UnityEngine.Object;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
+    name: "判定详情统计",
     zh: "在游戏总结的计分板中显示击打误差的详细信息（以帧为单位）",
     en: "Show detailed accuracy info in the score board.")]
 public class JudgeAccuracyInfo

--- a/AquaMai.Mods/UX/OneKeyEntryEnd.cs
+++ b/AquaMai.Mods/UX/OneKeyEntryEnd.cs
@@ -16,14 +16,15 @@ using Process;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
+    name: "一键登录与登出",
     en: "One key to proceed to music select (during entry) or end current PC (during music select).",
     zh: "一键跳过登录过程直接进入选歌界面，或在选歌界面直接结束本局游戏")]
 public class OneKeyEntryEnd
 {
-    [ConfigEntry]
+    [ConfigEntry(name: "按键")]
     public static readonly KeyCodeOrName key = KeyCodeOrName.Service;
 
-    [ConfigEntry]
+    [ConfigEntry(name: "长按")]
     public static readonly bool longPress = true;
 
     [HarmonyPrefix]

--- a/AquaMai.Mods/UX/OneKeyRetrySkip.cs
+++ b/AquaMai.Mods/UX/OneKeyRetrySkip.cs
@@ -10,20 +10,21 @@ using Process;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
+    name: "一键重开和跳过",
     en: "One key to retry (1.30+) or skip current chart in gameplay.",
     zh: "在游戏中途一键重试（1.30+）或跳过当前谱面")]
 public class OneKeyRetrySkip
 {
-    [ConfigEntry]
+    [ConfigEntry("重开按键")]
     public static readonly KeyCodeOrName retryKey = KeyCodeOrName.Service;
 
-    [ConfigEntry]
+    [ConfigEntry("重开长按")]
     public static readonly bool retryLongPress = false;
 
-    [ConfigEntry]
+    [ConfigEntry("跳关按键")]
     public static readonly KeyCodeOrName skipKey = KeyCodeOrName.Service;
 
-    [ConfigEntry]
+    [ConfigEntry("跳关长按")]
     public static readonly bool skipLongPress = true;
 
     private static bool dirty = false;

--- a/AquaMai.Mods/UX/PracticeMode/PracticeMode.cs
+++ b/AquaMai.Mods/UX/PracticeMode/PracticeMode.cs
@@ -22,10 +22,11 @@ namespace AquaMai.Mods.UX.PracticeMode;
 [ConfigCollapseNamespace]
 [ConfigSection(
     en: "Practice Mode.",
-    zh: "练习模式")]
+    name: "练习模式")]
 public class PracticeMode
 {
     [ConfigEntry(
+        name: "按键",
         en: "Key to show Practice Mode UI.",
         zh: "显示练习模式 UI 的按键")]
     public static readonly KeyCodeOrName key = KeyCodeOrName.Test;

--- a/AquaMai.Mods/UX/QuickEndPlay.cs
+++ b/AquaMai.Mods/UX/QuickEndPlay.cs
@@ -10,6 +10,7 @@ using UnityEngine;
 namespace AquaMai.Mods.UX;
 
 [ConfigSection(
+    name: "歌曲快速结束",
     en: "Show a \"skip\" button like AstroDX after the notes end.",
     zh: "音符结束之后显示像 AstroDX 一样的「跳过」按钮")]
 public class QuickEndPlay

--- a/AquaMai.Mods/UX/SelectionDetail.cs
+++ b/AquaMai.Mods/UX/SelectionDetail.cs
@@ -20,6 +20,7 @@ namespace AquaMai.Mods.UX;
 
 [EnableGameVersion(23500)]
 [ConfigSection(
+    name: "歌曲详情",
     en: "Show detail of selected song in music selection screen.",
     zh: "选歌界面显示选择的歌曲的详情")]
 public class SelectionDetail

--- a/AquaMai.Mods/Utils/AntiLag.cs
+++ b/AquaMai.Mods/Utils/AntiLag.cs
@@ -9,14 +9,15 @@ using UnityEngine;
 namespace AquaMai.Mods.Utils;
 
 [ConfigSection(
+    name: "狂暴引擎",
     en: "Some tricks to prevent the system from lagging",
-    zh: "狂暴引擎（可能缓解掉帧，但也可能把狂暴转移到用户身上）")]
+    zh: "可能缓解掉帧，但也可能把狂暴转移到用户身上")]
 public class AntiLag : MonoBehaviour
 {
-    [ConfigEntry(zh: "游戏未取得焦点时也运行")]
+    [ConfigEntry(name: "后台运行", zh: "游戏未取得焦点时也运行")]
     private static readonly bool activateWhileBackground = false;
 
-    [ConfigEntry(zh: "将游戏设为高优先级")]
+    [ConfigEntry(name: "高优先级", zh: "将游戏设为高优先级")]
     private static readonly bool setHighPriority = true;
 
     [HarmonyPostfix]

--- a/AquaMai.Mods/Utils/DisplayFrameRate.cs
+++ b/AquaMai.Mods/Utils/DisplayFrameRate.cs
@@ -7,8 +7,8 @@ using UnityEngine;
 namespace AquaMai.Mods.Utils;
 
 [ConfigSection(
-    en: "Display framerate.",
-    zh: "显示帧率")]
+    name: "显示帧率",
+    en: "Display framerate.")]
 public class DisplayFrameRate
 {
     [HarmonyPatch(typeof(GameMainObject), "Awake")]

--- a/AquaMai.Mods/Utils/DisplayTouchInGame.cs
+++ b/AquaMai.Mods/Utils/DisplayTouchInGame.cs
@@ -35,7 +35,7 @@ public static class DisplayTouchInGame
         zh: "默认显示。关了的话，可以用按键切换显示")]
     public static bool defaultOn = true;
 
-    [ConfigEntry(zh: "按键切换显示")]
+    [ConfigEntry(name: "切换显示按键")]
     public static readonly KeyCodeOrName key = KeyCodeOrName.None;
     [ConfigEntry] private static readonly bool longPress = false;
 

--- a/AquaMai.Mods/Utils/LogNetworkRequests.cs
+++ b/AquaMai.Mods/Utils/LogNetworkRequests.cs
@@ -16,23 +16,25 @@ using AquaMai.Core.Helpers;
 namespace AquaMai.Mods.Utils;
 
 [ConfigSection(
+    name: "网络请求日志",
     en: "Log network requests to the MelonLoader console.",
     zh: "将网络请求输出到 MelonLoader 控制台")]
 public class LogNetworkRequests
 {
-    [ConfigEntry]
+    [ConfigEntry(name: "URL")]
     private static readonly bool url = true;
 
-    [ConfigEntry]
+    [ConfigEntry(name: "请求")]
     private static readonly bool request = true;
-    [ConfigEntry]
+    [ConfigEntry(name: "省略以下请求")]
     private static readonly string requestOmittedApis = "UploadUserPhotoApi,UploadUserPortraitApi";
 
-    [ConfigEntry]
+    [ConfigEntry(name: "响应")]
     private static readonly bool response = true;
-    [ConfigEntry]
+    [ConfigEntry(name: "省略以下响应")]
     private static readonly string responseOmittedApis = "GetGameEventApi";
     [ConfigEntry(
+        name: "仅输出错误",
         en: "Only print error responses, without the successful ones.",
         zh: "仅输出出错的响应，不输出成功的响应")]
     private static readonly bool responseErrorOnly = false;

--- a/AquaMai.Mods/Utils/LogUnity.cs
+++ b/AquaMai.Mods/Utils/LogUnity.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 namespace AquaMai.Mods.Utils;
 
 [ConfigSection(
+    name: "Unity 日志",
     en: "Output Unity logs (for debugging purposes)",
     zh: "输出 Unity 日志（调试用）",
     exampleHidden: true)]

--- a/AquaMai.Mods/Utils/LogUserId.cs
+++ b/AquaMai.Mods/Utils/LogUserId.cs
@@ -9,6 +9,7 @@ using Net.VO.Mai2;
 namespace AquaMai.Mods.Utils;
 
 [ConfigSection(
+    name: "用户 ID 日志",
     en: "Log user ID on login.",
     zh: "登录时将 UserID 输出到日志")]
 public class LogUserId

--- a/AquaMai.Mods/Utils/MoveAnswerSound.cs
+++ b/AquaMai.Mods/Utils/MoveAnswerSound.cs
@@ -19,21 +19,24 @@ using UserOption = Manager.UserDatas.UserOption;
 namespace AquaMai.Mods.Utils;
 
 [ConfigSection(
-    en: "Move answer sound",
-    zh: "移动正解音")]
+    name: "移动正解音",
+    en: "Move answer sound")]
 public class MoveAnswerSound : IPlayerSettingsItem
 {
     [ConfigEntry(
+        name: "游戏内设置",
         en: "Display in-game config entry for player. If disabled, the user's settings will be ignored.",
         zh: "在游戏内添加设置项给用户，使用户能够在游戏内调整正解音偏移量。如果关闭此选项，则就算用户之前设置过，也会忽略。")]
     private static readonly bool DisplayInGameConfig = true;
     
     [ConfigEntry(
+        name: "1P 偏移量",
         en: "Answer sound move value in ms, this value will be combined with user's setting in game. Increase this value to make the answer sound appear later, vice versa.",
         zh: "正解音偏移量，单位为毫秒，此设定值会与用户游戏内的设置相加。增大这个值将会使正解音出现得更晚，反之则更早。")]
     private static readonly float MoveValue_1P = 0f;
     
     [ConfigEntry(
+        name: "2P 偏移量",
         en: "Same as MoveValue_1P.",
         zh: "与 MoveValue_1P 作用相同。")]
     private static readonly float MoveValue_2P = 0f;

--- a/AquaMai.Mods/Utils/ScreenPositionAdjust.cs
+++ b/AquaMai.Mods/Utils/ScreenPositionAdjust.cs
@@ -14,6 +14,7 @@ using UnityEngine.UI;
 namespace AquaMai.Mods.Utils;
 
 [ConfigSection(
+    name: "屏幕位置调整",
     zh: """
         屏幕位置调整。适用于手台对不齐的情况，可以分别调整每个屏幕区域的位置
         在游戏中按键开启调整模式
@@ -29,9 +30,9 @@ namespace AquaMai.Mods.Utils;
 )]
 public class ScreenPositionAdjust
 {
-    [ConfigEntry(zh: "上屏紧贴着下屏", en: "Top screen is tightly attached to the bottom screen")]
+    [ConfigEntry(name: "上屏紧贴着下屏", en: "Top screen is tightly attached to the bottom screen")]
     public static readonly bool compactMode = false;
-    [ConfigEntry(zh: "进入调整模式的按键", en: "Key to enter adjustment mode")]
+    [ConfigEntry(name: "进入调整模式的按键", en: "Key to enter adjustment mode")]
     public static readonly KeyCodeOrName adjustKey = KeyCodeOrName.F10;
 
     private static GameObject root;

--- a/AquaMai.Mods/Utils/ShowErrorLog.cs
+++ b/AquaMai.Mods/Utils/ShowErrorLog.cs
@@ -16,13 +16,16 @@ using BuildInfo = AquaMai.Core.BuildInfo;
 namespace AquaMai.Mods.Utils;
 
 [ConfigSection(
+    name: "崩溃报错",
     en: "Show error log in the game.",
-    zh: "在游戏中显示错误日志窗口而不是关闭游戏进程")]
+    zh: "在游戏中显示错误日志窗口而不是关闭游戏进程",
+    defaultOn: true)]
 public class ShowErrorLog
 {
     private static Ui _errorUi;
 
     [ConfigEntry(
+        name: "崩溃窗口",
         en: "Use new error handler",
         zh: "使用新版错误报告生成器")]
     private static readonly bool useNewErrorHandler = true;

--- a/AquaMai.Mods/Utils/ShowNetErrorDetail.cs
+++ b/AquaMai.Mods/Utils/ShowNetErrorDetail.cs
@@ -13,7 +13,7 @@ namespace AquaMai.Mods.Utils;
 
 [ConfigSection(
     en: "Show Network error detail in the game when gray network icon appears.",
-    zh: "出现灰网时显示原因",
+    name: "灰网时显示原因",
     defaultOn: true)]
 public class ShowNetErrorDetail
 {

--- a/AquaMai/configSort.yaml
+++ b/AquaMai/configSort.yaml
@@ -9,7 +9,6 @@
   - GameSystem.TouchToButtonInput
   - GameSystem.TestProof
   - GameSettings.CreditConfig
-  - Fancy.GamePlay.ExtendNotesPool
   - Utils.MoveAnswerSound
 
 全解和跳过:
@@ -65,7 +64,6 @@
   - Utils.DisplayFrameRate
   - Utils.LogUserId
   - Utils.LogNetworkRequests
-  - Utils.ShowErrorLog
   - UX.HardwareAlert
 
 键位和灵敏度:
@@ -102,10 +100,12 @@
   - UX.DontRuinMyAccount
   - UX.Hide1879
   - UX.GrantFinalGateKey
+  - Fancy.GamePlay.ExtendNotesPool
   - Tweaks.TimeSaving.SkipStartupWarning
   - Tweaks.TimeSaving.SkipStartupDelays
   - Utils.ShowNetErrorDetail
   - Tweaks.IgnoreAimeServerError
   - UX.NoAmDaemonAlert
+  - Utils.ShowErrorLog
   - GameSettings.ForceAsServer
   - GameSystem.RemoveEncryption


### PR DESCRIPTION
<img width="403" height="464" alt="Snipaste_2025-10-03_21-23-19" src="https://github.com/user-attachments/assets/54234aca-f366-4349-856e-b4abddde9ac0" />
这里没有 Squash and Merge

## Sourcery 总结

为配置节和配置项添加自定义显示名称的支持，将这些名称传播到本地化中，并提升配置 API 版本。使用显式的 `name` 参数更新所有现有的配置属性，并增强注释处理，使其在中文输出中包含名称。还在服务器资源中注解可为空的字段，并将 API 版本增加到 1.1。

改进：
- 在 `ConfigSectionAttribute` 和 `ConfigEntryAttribute` 中引入 `name` 参数，并更新所有配置类以指定本地化名称
- 增强 `ConfigComment`，使其在中文本地化中包含条目名称
- 使用 `CanBeNull` 注解 `ServerResourcesEntry` 字段，以反映其可空性
- 重新排序 `configSort.yaml` 条目

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for custom display names on configuration sections and entries, propagate those names into localization, and bump the config API. Update all existing config attributes with explicit `name` arguments and enhance comment handling to include names in Chinese output. Also annotate nullable fields in server resources and increment the API version to 1.1.

Enhancements:
- Introduce `name` parameter in ConfigSectionAttribute and ConfigEntryAttribute and update all config classes to specify localized names
- Enhance ConfigComment to include entry names in Chinese localization
- Annotate ServerResourcesEntry fields with CanBeNull to reflect nullability
- Reorder configSort.yaml entries

</details>