### PR TITLE
[F] DisableTimeout导致自由模式游戏崩溃

### DIFF
--- a/AquaMai.Mods/GameSystem/DisableTimeout.cs
+++ b/AquaMai.Mods/GameSystem/DisableTimeout.cs
@@ -57,7 +57,7 @@ public class DisableTimeout
         Traverse.Create(__instance).Property<bool>("IsInfinity").Value = true;
     }
 
-    private static MethodBase _updateFreedomModeCounter = typeof(TimerController).GetMethod("UpdateFreedomModeCounter", BindingFlags.NonPublic);
+    private static MethodBase _updateFreedomModeCounter = AccessTools.Method(typeof(TimerController), "UpdateFreedomModeCounter");
 
     [HarmonyPrefix]
     [HarmonyPatch(typeof(TimerController), nameof(TimerController.UpdateTimer))]


### PR DESCRIPTION
<img width="1408" height="1422" alt="屏幕截图 2025-10-07 013408" src="https://github.com/user-attachments/assets/43b96be1-cb1e-4f67-9802-99c5ca5107cc" />
该问题由 8d7d9cd 引入，关于相关代码，GPT是这么说的

https://github.com/MewoLab/AquaMai/blob/8d7d9cda1e91d135682ed9d9df758bafd35c8431/AquaMai.Mods/GameSystem/DisableTimeout.cs#L60

<img width="1471" height="1171" alt="image" src="https://github.com/user-attachments/assets/e8e6ffc9-706f-48ca-9423-b3e620f4b678" />

（今天刚旅完游回来到家，随手更了下AquaMai到最新开发版，打开自由模式，欸！崩了！然后启动上班模式x）

