### PR TITLE
修复UX.SelectionDetail在随机选曲不显示歌曲信息

### DIFF
--- a/AquaMai.Mods/UX/SelectionDetail.cs
+++ b/AquaMai.Mods/UX/SelectionDetail.cs
@@ -61,7 +61,7 @@ public class SelectionDetail
         var userData = Singleton<UserDataManager>.Instance.GetUserData(player);
         if (!userData.IsEntry) return;
 
-        if (____musicSelect.IsRandomIndex()) return;
+        if (____musicSelect.IsRandomIndex() && !____musicSelect.IsRandomSelected()) return;
 
         SelectData = ____musicSelect.GetMusic(0);
         if (SelectData == null) return;
@@ -70,6 +70,17 @@ public class SelectionDetail
         userGhost = Singleton<GhostManager>.Instance.GetGhostToEnum(ghostTarget);
 
         window[player] = player == 0 ? __instance.gameObject.AddComponent<P1Window>() : __instance.gameObject.AddComponent<P2Window>();
+    }
+
+    // 在随机选歌后， 不会调用 UpdateRivalScore，但是会调用 SetRivalScore
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(MusicSelectMonitor), "SetRivalScore")]
+    public static void AfterSetRivalScore(MusicSelectMonitor __instance, MusicSelectProcess ____musicSelect)
+    {
+        // 仅在随机选歌时生效
+        if (!____musicSelect.IsRandomSelected()) return;
+        // 手动触发窗口更新
+        ScrollUpdate(____musicSelect, __instance);
     }
 
     private class P1Window : Window


### PR DESCRIPTION
## Sourcery 总结

修复 UX.SelectionDetail，使其在随机歌曲选择期间通过更新随机选择检查并触发手动刷新来正确显示歌曲信息。

错误修复：
- 通过优化 IsRandomIndex 条件，允许在随机歌曲被选中时运行 ScrollUpdate。
- 在 MusicSelectMonitor.SetRivalScore 上添加一个 HarmonyPostfix，以便在随机选择后手动调用 ScrollUpdate。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix UX.SelectionDetail to correctly show song information during random song selection by updating the random selection check and triggering a manual refresh.

Bug Fixes:
- Allow ScrollUpdate to run when a random song has been selected by refining the IsRandomIndex condition.
- Add a HarmonyPostfix on MusicSelectMonitor.SetRivalScore to manually invoke ScrollUpdate after a random selection.

</details>