### PR TITLE
修复 fixTrackNumDisplay 对于 longtrack 的处理

### DIFF
--- a/AquaMai.Mods/UX/FixTrackNumDisplay.cs
+++ b/AquaMai.Mods/UX/FixTrackNumDisplay.cs
@@ -11,28 +11,55 @@ namespace AquaMai.Mods.UX;
 
 [ConfigSection(
     name: "两位数曲目修复",
-    en: "Make track number in top right corner display two digits",
-    zh: "让右上角的当前曲目数字可以显示两位数")]
+    en: "Make track number in top right corner display two digits (in Normal mode)",
+    zh: "让右上角的当前曲目数字可以显示两位数（在普通模式中）")]
 public class FixTrackNumDisplay
 {
-    [ConfigEntry(
-        name: "显示格式",
-        en: "Track number display style: 0=Left-padded (_5), 1=Zero-padded (05), 2=Right-padded (5_)",
-        zh: "曲目数字显示格式: 0=左侧补空格(_5), 1=左侧补零(05), 2=右侧补空格(5_)")]
-    private static readonly int TrackNumDisplayStyle = 0; // Default 0
-
     private static Sprite[] customSprites;
     private static bool isInitialized = false;
 
+    // 记录原始数据，以便恢复到原版显示
+    private static Sprite[] originalSprites;
+    private static Vector2 originalSizeDelta;
+    private static Vector2 originalTextDefaultScale1;
+    private static Vector2 originalTextDefaultScale2;
+    private static float originalTextScale1;
+    private static float originalTextScale2;
+    private static Vector2 originalTextPos1;
+    private static Vector2 originalTextPos2;
+
+
     [HarmonyPostfix]
     [HarmonyPatch(typeof(CommonMonitor), "SetTrackCount")]
-    public static void SetTrackCountPostfix(MultipleImage ____trackCountObject)
+    public static void SetTrackCountPostfix(uint maxTrackNum,
+                                            MultipleImage ____trackCountObject,
+                                            SpriteCounter ____trackCountText,
+                                            SpriteCounter ____trackDenominatortText)
     {
         if (isInitialized) return;
 
         try {
+            // 记录原始贴图尺寸
+            var rectTransform = ____trackCountObject.GetComponent<RectTransform>();
+            originalSizeDelta = rectTransform.sizeDelta;
+            // 记录原始文字尺寸
+            originalTextDefaultScale1 = ____trackCountText.FrameList[0].DefaultScale;
+            originalTextDefaultScale2 = ____trackDenominatortText.FrameList[0].DefaultScale;
+            originalTextScale1 = ____trackCountText.FrameList[0].Scale;
+            originalTextScale2 = ____trackDenominatortText.FrameList[0].Scale;
+            // 记录原始文字位置
+            originalTextPos1 = ____trackCountText.FrameList[0].RelativePosition;
+            originalTextPos2 = ____trackDenominatortText.FrameList[0].RelativePosition;
+
+
             customSprites = new Sprite[3];
             var trackSprites = ____trackCountObject.MultiSprites; // 0: Blue, 1: Green, 2: Red
+
+            // 记录原始贴图
+            originalSprites = new Sprite[3];
+            for (int i = 0; i < 3; i++) {
+                originalSprites[i] = trackSprites[i];
+            }
 
             for (int i = 0; i < 3; i++) {
                 int w = trackSprites[i].texture.width;
@@ -76,25 +103,77 @@ public class FixTrackNumDisplay
 
     [HarmonyPrefix]
     [HarmonyPatch(typeof(CommonMonitor), "SetTrackCount")]
-    public static bool SetTrackCountPrefix(uint currentTrackNum, uint maxTrackNum, 
+    public static bool SetTrackCountPrefix(uint currentTrackNum, uint maxTrackNum,
                                             MultipleImage ____trackCountObject,
                                             SpriteCounter ____trackCountText,
                                             SpriteCounter ____trackDenominatortText,
                                             GameObject ____trackMaskImage,
                                             Color[] ____trackColor)
     {
-        if (maxTrackNum < 10) return true;
         if (!isInitialized) return true;
         if (currentTrackNum < 1) return true;
-        if (GameManager.IsFreedomMode) return true;
+        if (!GameManager.IsNormalMode) return true; // 仅在普通模式下生效
 
-        try {
-            // 在前两局进行调整
-            if (currentTrackNum < 3) {
+
+
+        // 当 currentTrackNum 和 maxTrackNum 都 <10 时，恢复到原版显示
+        if (currentTrackNum < 10 && maxTrackNum < 10)
+        {
+            // 先做一个基础判断，看看是否已经是原本的样子
+            if (____trackCountText.FrameList.Count == 1 && ____trackDenominatortText.FrameList.Count == 1) return true;
+
+            try
+            {
+                // 恢复原版贴图
+                var trackSprites = ____trackCountObject.MultiSprites;
+                for (int i = 0; i < 3; i++)
+                {
+                    trackSprites[i] = originalSprites[i];
+                }
+                // 恢复原版贴图尺寸
+                var rectTransform = ____trackCountObject.GetComponent<RectTransform>();
+                Vector2 sizeDelta = rectTransform.sizeDelta;
+                if (sizeDelta.x != originalSizeDelta.x) rectTransform.sizeDelta = originalSizeDelta;
+                // 恢复原版文字位数
+                if (____trackCountText.FrameList.Count != 1)
+                {
+                    while (____trackCountText.FrameList.Count > 1)
+                        ____trackCountText.RemoveFormatFrame();
+                }
+                if (____trackDenominatortText.FrameList.Count != 1)
+                {
+                    while (____trackDenominatortText.FrameList.Count > 1)
+                        ____trackDenominatortText.RemoveFormatFrame();
+                }
+                // 恢复原版文字尺寸
+                ____trackCountText.FrameList[0].DefaultScale = originalTextDefaultScale1;
+                ____trackDenominatortText.FrameList[0].DefaultScale = originalTextDefaultScale2;
+                ____trackCountText.FrameList[0].Scale = originalTextScale1;
+                ____trackDenominatortText.FrameList[0].Scale = originalTextScale2;
+                // 恢复原版文字位置
+                ____trackCountText.FrameList[0].RelativePosition = originalTextPos1;
+                ____trackDenominatortText.FrameList[0].RelativePosition = originalTextPos2;
+            }
+            catch (Exception e)
+            {
+                MelonLogger.Msg($"[FixTrackNumDisplay] Reset to origin error: {e}");
+            }
+            return true; // 使用原版逻辑
+        }
+
+
+
+        // 现在是 currentTrackNum 或 maxTrackNum >= 10，需要使用自定义显示
+        try
+        {
+            // 先做一个基础判断，看看是否需要改变样式
+            if (____trackCountText.FrameList.Count == 1 || ____trackDenominatortText.FrameList.Count == 1)
+            {
                 // 右边增加30像素, 匹配新的贴图尺寸
                 var rectTransform = ____trackCountObject.GetComponent<RectTransform>();
                 Vector2 sizeDelta = rectTransform.sizeDelta;
-                if (sizeDelta.x != 290) rectTransform.sizeDelta = new Vector2(290f, sizeDelta.y);
+                var newX = originalSizeDelta.x + 30;
+                if (sizeDelta.x != newX) rectTransform.sizeDelta = new Vector2(newX, sizeDelta.y);
                 // 显示位置增加到两位
                 if (____trackCountText.FrameList.Count != 2) ____trackCountText.AddFormatFream();
                 if (____trackDenominatortText.FrameList.Count != 2) ____trackDenominatortText.AddFormatFream();
@@ -112,13 +191,8 @@ public class FixTrackNumDisplay
             var curStr = currentTrackNum.ToString();
             var maxStr = maxTrackNum.ToString();
 
-            // 根据配置选择显示格式
-            curStr = TrackNumDisplayStyle switch {
-                0 => curStr.PadLeft(2),      //左侧空格补位
-                1 => curStr.PadLeft(2, '0'), //左侧零补位
-                2 => curStr.PadRight(2),     //右侧空格补位
-                _ => curStr.PadLeft(2),      //默认 case 0
-            };
+            // 统一使用左侧空格补位
+            curStr = curStr.PadLeft(2);
 
             // 默认文字位置
             ____trackCountText.FrameList[0].RelativePosition = new Vector2(5, 0);
@@ -129,34 +203,36 @@ public class FixTrackNumDisplay
             // 数字1的位置需要额外调整，以保证视觉上与其它数字间距一致
             // currentTrackNum 第一位
             if (curStr[0] == '1' && curStr[1] != ' ')
-                ____trackCountText.FrameList[0].RelativePosition = new Vector2(5+2, 0);
+                ____trackCountText.FrameList[0].RelativePosition = new Vector2(5 + 2, 0);
             // currentTrackNum 第二位
             if (curStr[1] == '1' && curStr[0] != ' ')
-                ____trackCountText.FrameList[1].RelativePosition = new Vector2(-7-2, 0);
+                ____trackCountText.FrameList[1].RelativePosition = new Vector2(-7 - 2, 0);
             // maxTrackNum 第一位
             if (maxStr[0] == '1')
-                ____trackDenominatortText.FrameList[0].RelativePosition = new Vector2(33+2, 0);                
+                ____trackDenominatortText.FrameList[0].RelativePosition = new Vector2(33 + 2, 0);
             // maxTrackNum 第二位
             if (maxStr[1] == '1')
-                ____trackDenominatortText.FrameList[1].RelativePosition = new Vector2(16-2, 0);
+                ____trackDenominatortText.FrameList[1].RelativePosition = new Vector2(16 - 2, 0);
 
-            // 复制原版处理非自由模式的逻辑
+            // 复制原版处理普通模式的逻辑
             var trackColorID = 0;
             ____trackMaskImage.SetActive(value: false);
             ____trackCountText.ChangeText(curStr); // 使用自定义文本
             ____trackDenominatortText.ChangeText(maxStr);
             trackColorID = (maxTrackNum - currentTrackNum) switch
             {
-                0u => 2, 
-                1u => 1, 
-                _ => 0, 
+                0u => 2,
+                1u => 1,
+                _ => 0,
             };
             ____trackCountObject.sprite = customSprites[trackColorID]; // 使用自定义贴图
             ____trackCountText.SetColor(____trackColor[trackColorID]);
             ____trackDenominatortText.SetColor(____trackColor[trackColorID]);
             return false;
-            
-        } catch (Exception e) {
+
+        }
+        catch (Exception e)
+        {
             MelonLogger.Msg($"[FixTrackNumDisplay] {e}");
             return true;
         }


### PR DESCRIPTION
由于 longtrack 会让 maxTrackNum - 1，可能出现一开始 maxTrackNum >= 10 但是玩了几首后 maxTrackNum < 10 的情况。

## Sourcery 摘要

增强赛道编号显示模组，以便在 maxTrackNum 波动时（例如在长距离赛道会话中），通过捕获和恢复原始 UI 参数，正确地在自定义两位数和原始一位数布局之间切换，并将自定义显示限制在 Normal 模式。

错误修复：
- 当 maxTrackNum 在会话中途降至 10 以下时，恢复原始的一位数显示，以处理长距离赛道的边缘情况

功能增强：
- 记录原始精灵图、大小、缩放和位置，以实现显示模式之间的无缝切换
- 始终为两位数格式应用左侧空格填充，并移除可配置的填充样式
- 动态调整 UI 宽度和字符位置，以实现一致的两位数渲染

文档：
- 在配置说明中阐明两位数显示仅适用于 Normal 模式

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the track number display mod to correctly switch between custom two-digit and original single-digit layouts when maxTrackNum fluctuates (e.g. in longtrack sessions), by capturing and restoring original UI parameters, and restrict custom display to Normal mode.

Bug Fixes:
- Restore original single-digit display when maxTrackNum drops below 10 mid-session to handle longtrack edge cases

Enhancements:
- Record original sprites, sizes, scales, and positions to enable seamless toggling between display modes
- Always apply left-space padding for two-digit formatting and remove configurable padding styles
- Adjust UI width and character positioning dynamically for consistent two-digit rendering

Documentation:
- Clarify in the config description that two-digit display applies only in Normal mode

</details>