### PR TITLE
交换练习模式ui样式

### DIFF
--- a/AquaMai.Mods/UX/PracticeMode/Libs/PractiseModeUI.cs
+++ b/AquaMai.Mods/UX/PracticeMode/Libs/PractiseModeUI.cs
@@ -60,29 +60,29 @@ public class PracticeModeUI : MonoBehaviour
         GUI.Button(GetButtonRect(1, 0), Locale.Pause);
         GUI.Button(GetButtonRect(2, 0), Locale.SeekForward);
 
+        GUI.Button(GetButtonRect(0, 1), Locale.SpeedDown);
+        GUI.Label(GetButtonRect(1, 1), $"{Locale.Speed} {PracticeMode.speed * 100:000}%");
+        GUI.Button(GetButtonRect(2, 1), Locale.SpeedUp);
+
         if (PracticeMode.repeatStart == -1)
         {
-            GUI.Button(GetButtonRect(0, 1), Locale.MarkRepeatStart);
-            GUI.Label(GetButtonRect(1, 1), Locale.RepeatNotSet);
+            GUI.Button(GetButtonRect(0, 2), Locale.MarkRepeatStart);
+            GUI.Label(GetButtonRect(1, 2), Locale.RepeatNotSet);
         }
         else if (PracticeMode.repeatEnd == -1)
         {
-            GUI.Button(GetButtonRect(0, 1), Locale.MarkRepeatEnd);
-            GUI.Label(GetButtonRect(1, 1), Locale.RepeatStartSet);
-            GUI.Button(GetButtonRect(2, 1), Locale.RepeatReset);
+            GUI.Button(GetButtonRect(0, 2), Locale.MarkRepeatEnd);
+            GUI.Label(GetButtonRect(1, 2), Locale.RepeatStartSet);
+            GUI.Button(GetButtonRect(2, 2), Locale.RepeatReset);
         }
         else
         {
-            GUI.Label(GetButtonRect(1, 1), Locale.RepeatStartEndSet);
-            GUI.Button(GetButtonRect(2, 1), Locale.RepeatReset);
+            GUI.Label(GetButtonRect(1, 2), Locale.RepeatStartEndSet);
+            GUI.Button(GetButtonRect(2, 2), Locale.RepeatReset);
         }
 
-        GUI.Button(GetButtonRect(0, 2), Locale.SpeedDown);
-        GUI.Label(GetButtonRect(1, 2), $"{Locale.Speed} {PracticeMode.speed * 100:000}%");
-        GUI.Button(GetButtonRect(2, 2), Locale.SpeedUp);
-        GUI.Button(GetButtonRect(1, 3), Locale.SpeedReset);
-
         GUI.Label(GetButtonRect(0, 3), $"{TimeSpan.FromMilliseconds(PracticeMode.CurrentPlayMsec):mm\\:ss\\.fff}\n{TimeSpan.FromMilliseconds(NotesManager.Instance().getPlayFinalMsec()):mm\\:ss\\.fff}");
+        GUI.Button(GetButtonRect(1, 3), Locale.SpeedReset);
         GUI.Button(GetButtonRect(2, 3), $"保持流速\n{(PracticeMode.keepNoteSpeed ? "ON" : "OFF")}");
     }
 
@@ -104,6 +104,14 @@ public class PracticeModeUI : MonoBehaviour
                 PracticeMode.Seek(0);
             }
         }
+        else if (InputManager.GetTouchPanelAreaDown(InputManager.TouchPanelArea.B6))
+        {
+            PracticeMode.SpeedDown();
+        }
+        else if (InputManager.GetTouchPanelAreaDown(InputManager.TouchPanelArea.B3))
+        {
+            PracticeMode.SpeedUp();
+        }
         else if (InputManager.GetTouchPanelAreaDown(InputManager.TouchPanelArea.B7) && PracticeMode.repeatStart == -1)
         {
             PracticeMode.repeatStart = PracticeMode.CurrentPlayMsec;
@@ -115,14 +123,6 @@ public class PracticeModeUI : MonoBehaviour
         else if (InputManager.GetTouchPanelAreaDown(InputManager.TouchPanelArea.B2))
         {
             PracticeMode.ClearRepeat();
-        }
-        else if (InputManager.GetTouchPanelAreaDown(InputManager.TouchPanelArea.B6))
-        {
-            PracticeMode.SpeedDown();
-        }
-        else if (InputManager.GetTouchPanelAreaDown(InputManager.TouchPanelArea.B3))
-        {
-            PracticeMode.SpeedUp();
         }
         else if (InputManager.GetTouchPanelAreaDown(InputManager.TouchPanelArea.B5) || InputManager.GetTouchPanelAreaDown(InputManager.TouchPanelArea.B4))
         {


### PR DESCRIPTION
更改练习模式2/3行触控及内容，以防止前进/后退造成的解除循环误触

## Sourcery 总结

调整练习模式UI中速度和重复控制的行，将速度调整放在第二行，重复标记放在第三行，以防止意外移除循环。

增强功能：
- 重新排列练习模式UI，使速度控制位于第二行，重复控制位于第三行
- 更新加速/减速的触控输入映射，以匹配其新的按钮位置
- 重新定位速度重置按钮和循环标记控制，以与更新的布局对齐

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Swap practice mode UI rows for speed and repeat controls to prevent accidental loop removal by placing speed adjustments on the second row and repeat markers on the third row

Enhancements:
- Rearrange practice mode UI so speed controls are on the second row and repeat controls on the third row
- Update touch input mappings for speed up/down to match their new button positions
- Relocate the speed reset button and loop marker controls to align with the updated layout

</details>