### PR TITLE
[+] Logo标志全屏展示

### DIFF
--- a/AquaMai.Mods/Fancy/CustomLogo.cs
+++ b/AquaMai.Mods/Fancy/CustomLogo.cs
@@ -29,6 +29,12 @@ public class CustomLogo
         zh: "从此目录中随机选择一张 PNG 图片用于「ALL.Net」标志")]
     private static readonly string allNetLogoDir = "LocalAssets/AllNetLogo";
 
+    [ConfigEntry(
+        name: "Logo 全屏幕",
+        en: "FullScreen the logo for the bottom screen.",
+        zh: "将标志全屏占满下屏幕")]
+    private static readonly bool logoFullScreen = false;
+
     private readonly static List<Sprite> segaLogo = [];
     private readonly static List<Sprite> allNetLogo = [];
 
@@ -65,6 +71,9 @@ public class CustomLogo
                 if (go == null)
                     go = monitor.transform.Find("Canvas/Main/UI_ADV_SegaAllNet/Null_all/SegaLogo");
                 go.GetComponent<Image>().sprite = logo;
+                if (!logoFullScreen) continue;
+                var rect = go.GetComponent<RectTransform>();
+                rect.sizeDelta = new Vector2(1080, 1080);
             }
         }
 
@@ -77,6 +86,9 @@ public class CustomLogo
                 if (go == null)
                     go = monitor.transform.Find("Canvas/Main/UI_ADV_SegaAllNet/Null_all/AllNetLogo");
                 go.GetComponent<Image>().sprite = logo;
+                if (!logoFullScreen) continue;
+                var rect = go.GetComponent<RectTransform>();
+                rect.sizeDelta = new Vector2(1080, 1080);
             }
         }
     }


### PR DESCRIPTION
## Sourcery 总结

引入一个配置设置，以可选地拉伸标志精灵使其填满整个底部屏幕，并对世嘉和AllNet标志应用适当的尺寸调整。

新功能：
- 添加一个配置选项，以在底部屏幕上全屏显示标志

改进：
- 当全屏功能启用时，将世嘉和AllNet标志调整大小到 1080×1080

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configuration setting to optionally stretch the logo sprites to fill the entire bottom screen and apply the appropriate resizing for both Sega and AllNet logos.

New Features:
- Add a config option to full-screen the logo on the bottom screen

Enhancements:
- Resize Sega and AllNet logos to 1080×1080 when full-screen is enabled

</details>