### PR TITLE
[+] Logo标志全屏展示

### DIFF
--- a/AquaMai.Mods/Fancy/CustomLogo.cs
+++ b/AquaMai.Mods/Fancy/CustomLogo.cs
@@ -29,6 +29,12 @@ public class CustomLogo
         zh: "从此目录中随机选择一张 PNG 图片用于「ALL.Net」标志")]
     private static readonly string allNetLogoDir = "LocalAssets/AllNetLogo";
 
+    [ConfigEntry(
+        name: "Logo 全屏幕",
+        en: "FullScreen the logo for the bottom screen.",
+        zh: "将标志全屏占满下屏幕")]
+    private static readonly bool logoFullScreen = false;
+
     private readonly static List<Sprite> segaLogo = [];
     private readonly static List<Sprite> allNetLogo = [];
 
@@ -65,6 +71,11 @@ public class CustomLogo
                 if (go == null)
                     go = monitor.transform.Find("Canvas/Main/UI_ADV_SegaAllNet/Null_all/SegaLogo");
                 go.GetComponent<Image>().sprite = logo;
+                if (!logoFullScreen) continue;
+                var rect = go.GetComponent<RectTransform>();
+                rect.sizeDelta = new Vector2(1080, 1080);
+                rect.offsetMin = new Vector2(-540, -540);
+                rect.offsetMax = new Vector2(540, 540);
             }
         }
 
@@ -77,6 +88,11 @@ public class CustomLogo
                 if (go == null)
                     go = monitor.transform.Find("Canvas/Main/UI_ADV_SegaAllNet/Null_all/AllNetLogo");
                 go.GetComponent<Image>().sprite = logo;
+                if (!logoFullScreen) continue;
+                var rect = go.GetComponent<RectTransform>();
+                rect.sizeDelta = new Vector2(1080, 1080);
+                rect.offsetMin = new Vector2(-540, -540);
+                rect.offsetMax = new Vector2(540, 540);
             }
         }
     }


### PR DESCRIPTION
## Sourcery 总结

添加一个配置选项，用于在底部显示器上全屏显示 Sega 和 AllNet 标志，并在启用时应用相应的调整大小逻辑。

新功能：
- 引入一个名为 "logoFullScreen" 的配置项，用于切换全屏标志显示。

改进：
- 当全屏模式启用时，调整 Sega 标志的大小和位置，以覆盖整个底部屏幕。
- 当全屏模式启用时，调整 AllNet 标志的大小和位置，以覆盖整个底部屏幕。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configuration option to display the Sega and AllNet logos in full-screen on the bottom monitor and apply the corresponding resizing logic when enabled.

New Features:
- Introduce a "logoFullScreen" config entry to toggle full-screen logo display.

Enhancements:
- Resize and reposition Sega logo to cover the entire bottom screen when full-screen mode is enabled.
- Resize and reposition AllNet logo to cover the entire bottom screen when full-screen mode is enabled.

</details>