### PR TITLE
[F] 尝试修复曲目信息伪装功能的一些问题

### DIFF
--- a/AquaMai.Mods/Fancy/TrackCamouflage.cs
+++ b/AquaMai.Mods/Fancy/TrackCamouflage.cs
@@ -330,6 +330,33 @@ Camouflage jacket filename is ""<Music ID>_jacket"", jpg or png image are suppor
     }
     #endregion
 
+    #region AssetManager Patch
+    // Most parts of the game using this method to get jackets except others mentioned from above so I think that'll do the rest
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(AssetManager), "GetJacketTexture2D", argumentTypes: [typeof(int)])]
+    public static bool PreGetJacketTexture2DFromID(ref Texture2D __result, int id, AssetManager __instance)
+    {
+        if (!CamouflageCheck(id, out CamouflageInfo info))
+            return true;
+
+        __result = info.JacketTexture ?? __instance.GetJacketTexture2D("Jacket/UI_Jacket_000000.png");
+        return false;
+    }
+
+    // Seems no one is using this method but just make sure...
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(AssetManager), "GetJacketThumbTexture2D", argumentTypes: [typeof(int)])]
+    public static bool PreGetJacketThumbTexture2DFromID(ref Texture2D __result, int id, AssetManager __instance)
+    {
+        if (!CamouflageCheck(id, out CamouflageInfo info))
+            return true;
+
+        __result = info.JacketTexture ?? __instance.GetJacketThumbTexture2D("Jacket_S/UI_Jacket_000000_S.png");
+        return false;
+    }
+    #endregion
+
     #region Utilities
     private static bool CamouflageCheck(int musicID, out CamouflageInfo info)
     {


### PR DESCRIPTION
1. 部分用户的 MelonLoader 可能使用过旧的 Tomlet 库，导致伪装信息解析功能出错，目前缓解方案是改用直接通过 `TomlDocument` 读取值的方法手动解析，以保证兼容性
2. 后续检查旧版本的 a-cs.dll 发现 `GetGenreTexture(|List)` 方法的本地变量索引可能有变，为确保兼容性，改为在查找字节码时检测本地变量的类型而非索引，并且用 `MethodBody` 查找注入需要的本地变量
3. 为避免潜在的重复添加问题，调整了下伪装信息字典的追加方式
4. 添加对 `AssetManager.GetJacketTexture2D(int)` 方法的注入，以解决区域课题曲/完美挑战提示曲绘（和其它可能需要显示曲绘的地方）的问题
    - ps: 很奇怪，只有少部分地方是用曲绘文件名获取曲绘的，还有个用谱面 ID 获取小曲绘的方法但是似乎没地方用到，但为了确保万无一失还是先 patch 了