### PR TITLE
[F] SelectionDetail show 0.0 when player choosing Re:Master but the music has no Re:Master (Fix #81)

### DIFF
--- a/AquaMai.Mods/UX/SelectionDetail.cs
+++ b/AquaMai.Mods/UX/SelectionDetail.cs
@@ -107,7 +107,16 @@ public class SelectionDetail
                 dataToShow.Add(Singleton<DataManager>.Instance.GetMusicGenre(SelectData.MusicData.genreName.id)?.genreName);
             if (SelectData.MusicData.AddVersion is not null)
                 dataToShow.Add(Singleton<DataManager>.Instance.GetMusicVersion(SelectData.MusicData.AddVersion.id)?.genreName);
-            var notesData = SelectData.MusicData.notesData[difficulty[player]];
+            
+            var difficulty = SelectionDetail.difficulty[player];
+            var notesData = SelectData.MusicData.notesData[difficulty];
+            // Fix for player choosing Re:master but the music doesn't have Re:master
+            if (!notesData.isEnable && difficulty == 4)
+            {
+                difficulty = 3;
+                notesData = SelectData.MusicData.notesData[difficulty];
+            }
+            
             dataToShow.Add($"{notesData?.level}.{notesData?.levelDecimal}");
 
             if (userGhost != null)
@@ -115,21 +124,21 @@ public class SelectionDetail
                 dataToShow.Add(string.Format(Locale.UserGhostAchievement, $"{userGhost.Achievement / 10000m:0.0000}"));
             }
 
-            var rate = CalcB50(SelectData.MusicData, difficulty[player]);
+            var rate = CalcB50(SelectData.MusicData, difficulty);
             if (rate > 0)
             {
                 dataToShow.Add(string.Format(Locale.RatingUpWhenSSSp, rate));
             }
             else
             {
-                rate = CalcB50(SelectData.MusicData, difficulty[player], true);
+                rate = CalcB50(SelectData.MusicData, difficulty, true);
                 if (rate > 0)
                 {
                     dataToShow.Add(string.Format(Locale.RatingUpWhenAP, rate));
                 }
             }
 
-            var playCount = Shim.GetUserScoreList(userData)[difficulty[player]].FirstOrDefault(it => it.id == SelectData.MusicData.name.id)?.playcount ?? 0;
+            var playCount = Shim.GetUserScoreList(userData)[difficulty].FirstOrDefault(it => it.id == SelectData.MusicData.name.id)?.playcount ?? 0;
             if (playCount > 0)
             {
                 dataToShow.Add(string.Format(Locale.PlayCount, playCount));


### PR DESCRIPTION
Fix #81.

问题示意图如下：当上面选择了白谱难度时，Mai对没有白谱的歌会显示为紫谱的信息
<img width="1500" height="1489" alt="image" src="https://github.com/user-attachments/assets/345a7895-ec9d-44f9-ad59-76b7b34e4905" />

关于实现：也许有人会觉得“哇，居然是直接特判是否这首歌没有白谱，这实现好脏啊"
但，After仔细的调研，我惊讶的发现，Mai这个“对没有白谱的歌会显示为紫谱的信息”， **居然是在渲染层做的！** 数据层没有任何一个变量能够识别这种情况。
```C#
// 节选自Monitor.MusicSelect.ChainList.MusicSelectChainList:SetChainData，这是那个从左到右选歌的歌曲列表，是渲染层的东西
        if (!this.SelectProcess.IsRemasterEnable(index) && difficulty == 4)
          --difficulty;
```
Fine，所以就只能这样实现了，至少不比Sinmai本体脏（）