### PR TITLE
力大砖飞模组验证完成

### DIFF
--- a/AquaMai.Mods/Fancy/RsOverride.cs
+++ b/AquaMai.Mods/Fancy/RsOverride.cs
@@ -17,7 +17,7 @@ namespace AquaMai.Mods.Fancy;
 public class CustomSkinsPlusStatic
 {
     [ConfigEntry(name: "资源目录")]
-    private static string skinsDir = "LocalAssets/GlobalTextureOverride";
+    private static string skinsDir = "LocalAssets/ResourcesOverride";
 
     private static readonly Dictionary<string, Sprite> SpritePool = new Dictionary<string, Sprite>();
     private static readonly Dictionary<string, Texture2D> TexturePool = new Dictionary<string, Texture2D>();


### PR DESCRIPTION
目前未发现更多兼容性问题。测试于SDGB151+EZ156+160
修改部分表述
烦内就这样子吧）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `CustomSkinsPlusStatic` to load PNG overrides and forcibly replace `Image`/`RawImage` assets across the UI via Harmony patches.
> 
> - **Fancy Mod**:
>   - **New `CustomSkinsPlusStatic`** in `AquaMai.Mods/Fancy/RsOverride.cs` with `ConfigSection` and directory `ConfigEntry` (`LocalAssets/GlobalTextureOverride`).
>   - **Asset Loading**: Preloads `*.png` from the configured folder into `SpritePool`/`TexturePool` with normalized names.
>   - **Rendering Hooks**:
>     - Harmony `Prefix` on `Graphic.Rebuild` to swap `Image.sprite` and `RawImage.texture` with pool matches and reset renderer color.
>     - Harmony `Postfix` on `CanvasScaler.OnEnable` to bulk-scan children and replace matching sprites/textures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 692d10bb7d76c0145bab4479c5934e38317f4f70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->