### PR TITLE
Add unstable rate display

### DIFF
--- a/AquaMai.Mods/GameSystem/UnstableRate.cs
+++ b/AquaMai.Mods/GameSystem/UnstableRate.cs
@@ -1,4 +1,4 @@
-﻿using AquaMai.Config.Attributes;
+using AquaMai.Config.Attributes;
 using HarmonyLib;
 using MAI2.Util;
 using Manager;


### PR DESCRIPTION
This adds an unstable rate bar during gameplay that is heavily inspired by its equivalent in osu!. It shows for each hit whether the hit was early or late, with colored sections based on Critical (cyan), Perfect (blue), Great (green) and Good (yellow). Left is early, right is late. I attached a short clip to better illustrate it.

https://github.com/user-attachments/assets/40051dcb-ff81-443d-9deb-a0f8d379d169

It doesn't interact with touch notes or slide completion because those have much more lenient windows and it should be fairly obvious if you miss them anyway. It works for Tap, Hold start and Slide start. There are no special exceptions for Ex and Break notes.

I wasn't sure where exactly to put the new file, let me know if it should be moved. I also didn't provide any Chinese translations because I don't speak it (and don't trust Google Translate to not mess it up).