### PR TITLE
[O] 给SelectionDetail新增“推到鸟可上X分”的提示（之前只有鸟加和AP），同时修复了宴谱也会显示上分提示的bug

### DIFF
--- a/AquaMai.Core/Resources/Locale.Designer.cs
+++ b/AquaMai.Core/Resources/Locale.Designer.cs
@@ -290,6 +290,15 @@ namespace AquaMai.Core.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to SSS =&gt; DXRating += {0}.
+        /// </summary>
+        public static string RatingUpWhenSSS {
+            get {
+                return ResourceManager.GetString("RatingUpWhenSSS", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to SSS+ =&gt; DXRating += {0}.
         /// </summary>
         public static string RatingUpWhenSSSp {

--- a/AquaMai.Core/Resources/Locale.resx
+++ b/AquaMai.Core/Resources/Locale.resx
@@ -80,6 +80,9 @@
     <data name="NetErrWasDownloadSuccessOnce" xml:space="preserve">
         <value>Data download not success</value>
     </data>
+    <data name="RatingUpWhenSSS" xml:space="preserve">
+        <value>SSS =&gt; DXRating += {0}</value>
+    </data>
     <data name="RatingUpWhenSSSp" xml:space="preserve">
         <value>SSS+ =&gt; DXRating += {0}</value>
     </data>

--- a/AquaMai.Core/Resources/Locale.zh.resx
+++ b/AquaMai.Core/Resources/Locale.zh.resx
@@ -73,6 +73,9 @@
     <data name="NetErrWasDownloadSuccessOnce" xml:space="preserve">
         <value>数据下载不成功</value>
     </data>
+    <data name="RatingUpWhenSSS" xml:space="preserve">
+        <value>推到鸟可上 {0} 分</value>
+    </data>
     <data name="RatingUpWhenSSSp" xml:space="preserve">
         <value>推到鸟加可上 {0} 分</value>
     </data>

--- a/AquaMai.Mods/UX/SelectionDetail.cs
+++ b/AquaMai.Mods/UX/SelectionDetail.cs
@@ -11,7 +11,6 @@ using MAI2.Util;
 using Manager;
 using Manager.MaiStudio;
 using Manager.UserDatas;
-using MelonLoader;
 using Monitor;
 using Process;
 using UnityEngine;
@@ -124,19 +123,10 @@ public class SelectionDetail
                 dataToShow.Add(string.Format(Locale.UserGhostAchievement, $"{userGhost.Achievement / 10000m:0.0000}"));
             }
 
-            var rate = CalcB50(SelectData.MusicData, difficulty);
-            if (rate > 0)
-            {
-                dataToShow.Add(string.Format(Locale.RatingUpWhenSSSp, rate));
-            }
-            else
-            {
-                rate = CalcB50(SelectData.MusicData, difficulty, true);
-                if (rate > 0)
-                {
-                    dataToShow.Add(string.Format(Locale.RatingUpWhenAP, rate));
-                }
-            }
+            var (sssUp, ssspUp, apUp) = CalcScoreIncrements(SelectData.MusicData, difficulty);
+            if (sssUp > 0) dataToShow.Add(string.Format(Locale.RatingUpWhenSSS, sssUp));
+            else if (ssspUp > 0) dataToShow.Add(string.Format(Locale.RatingUpWhenSSSp, ssspUp));
+            else if (apUp > 0) dataToShow.Add(string.Format(Locale.RatingUpWhenAP, apUp));
 
             var playCount = Shim.GetUserScoreList(userData)[difficulty].FirstOrDefault(it => it.id == SelectData.MusicData.name.id)?.playcount ?? 0;
             if (playCount > 0)
@@ -160,24 +150,31 @@ public class SelectionDetail
             }
         }
 
-        private int CalcB50(MusicData musicData, int difficulty, bool ap = false)
+        /* 返回值：(推到SSS上的分, 推到SSS+上的分, 推到AP上的分) */
+        private (int sss, int sssp, int ap) CalcScoreIncrements(MusicData musicData, int difficulty)
         {
+            if (musicData.GetID() >= 100000) return (0, 0, 0); // 宴谱不计分
+            
             var musicId = musicData.name.id;
-            var aimRate = ap ? Shim.CreateUserRate(musicId, difficulty, 1010000, (uint)musicData.version, PlayComboflagID.AllPerfectPlus) :
-                Shim.CreateUserRate(musicId, difficulty, 1005000, (uint)musicData.version, PlayComboflagID.None);
-            var list = aimRate.OldFlag ? userData.RatingList.RatingList : userData.RatingList.NewRatingList;
-            var maxCount = aimRate.OldFlag ? 35 : 15;
-            uint userLowRate = 0;
+            var aimRates = ( // 假定推到了某个目标时，对应的UserRate
+                Shim.CreateUserRate(musicId, difficulty, 1000000, (uint)musicData.version, PlayComboflagID.None),
+                Shim.CreateUserRate(musicId, difficulty, 1005000, (uint)musicData.version, PlayComboflagID.None),
+                Shim.CreateUserRate(musicId, difficulty, 1010000, (uint)musicData.version, PlayComboflagID.AllPerfectPlus)
+            );
+            
+            var list = aimRates.Item1.OldFlag ? userData.RatingList.RatingList : userData.RatingList.NewRatingList;
+            var maxCount = aimRates.Item1.OldFlag ? 35 : 15;
+            int userLowRate = 0;
             if (list.Count == maxCount)
             {
                 var rate = list.Last();
-                userLowRate = rate.SingleRate;
+                userLowRate = (int)rate.SingleRate;
             }
 
             var userSongRate = list.FirstOrDefault(it => it.MusicId == musicId && it.Level == difficulty);
-            if (!userSongRate.Equals(default(UserRate))) userLowRate = userSongRate.SingleRate;
+            if (!userSongRate.Equals(default(UserRate))) userLowRate = (int)userSongRate.SingleRate;
 
-            return (int)aimRate.SingleRate - (int)userLowRate;
+            return ((int)aimRates.Item1.SingleRate - userLowRate, (int)aimRates.Item2.SingleRate - userLowRate, (int)aimRates.Item3.SingleRate - userLowRate);
         }
 
         public void Close()


### PR DESCRIPTION
如题，基本没什么太多说的。

motivation是某群里别人发的一张图：宴谱显示了“推到AP可上1分”，难绷
<img width="332" height="100" alt="Image_1774115144877_840" src="https://github.com/user-attachments/assets/906b3e2d-815b-46b0-a3eb-6e08bea55398" />

## Summary by Sourcery

在谱面选择详情中为达到 SSS 的成绩添加 DX Rating 提升提示，同时避免在宴谱谱面上显示评分提示。

新功能：
- 在谱面选择详情面板中，除了现有的 SSS+ 和 AP 提示外，新增达到 SSS 时的 DX Rating 提升提示。

错误修复：
- 避免在宴谱谱面上显示 DX Rating 提升提示，因为宴谱并不会计入 Rating。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add DX rating increment hints for reaching SSS in selection details while preventing rating hints from appearing on宴谱 charts.

New Features:
- Show DX rating increase hints for achieving SSS in the selection detail panel in addition to existing SSS+ and AP hints.

Bug Fixes:
- Avoid displaying DX rating increment hints for宴谱 charts, which do not contribute to rating.

</details>