### PR TITLE
[F] DisplayInTouch无法热开启：在游戏开始后再按键打开DisplayInTouch会无效，由于组件未被创建

### DIFF
--- a/AquaMai.Mods/Utils/DisplayTouchInGame.cs
+++ b/AquaMai.Mods/Utils/DisplayTouchInGame.cs
@@ -72,7 +72,7 @@ public static class DisplayTouchInGame
 
     [HarmonyPostfix]
     [HarmonyPatch(typeof(GameProcess), nameof(GameProcess.OnUpdate))]
-    public static void OnGameProcessUpdate()
+    public static void OnGameProcessUpdate(GameMonitor[] ____monitors)
     {
         for (int i = 0; i < 2; i++)
         {
@@ -86,6 +86,10 @@ public static class DisplayTouchInGame
         for (int i = 0; i < 2; i++)
         {
             if (canvasGameObjects[i] == null) continue;
+            if (displayType[i] > 0 && canvasGameObjects[i].Count == 0)
+            { // 能走到这里，说明肯定是触发了切换键的；现在displayType[i] > 0，说明功能肯定是刚刚才被打开的。因此如果canvasGameObject此前未被创建的话，则现在应该创建之。
+                CreateDisplay(displayType[i], ____monitors[i]);
+            }
             foreach (var go in canvasGameObjects[i])
             {
                 if (go == null) continue;
@@ -107,31 +111,30 @@ public static class DisplayTouchInGame
     [HarmonyPatch(typeof(GameProcess), nameof(GameProcess.OnStart))]
     public static void OnGameStart(GameMonitor[] ____monitors)
     {
-        if (prefab == null)
-        {
-            MelonLogger.Error("[DisplayTouchInGame] prefab is null");
-            return;
-        }
-
         for (int i = 0; i < 2; i++)
         {
             canvasGameObjects[i].Clear();
             var type = displayType[i];
             if (type is < 1 or > 5) continue;
-            if (type is 4 or 5)
-            {
-                CreateDisplay(3, ____monitors[i]);
-                type -= 3;
-            }
-            if (type > 3) continue;
             CreateDisplay(type, ____monitors[i]);
         }
     }
 
-    // type 只能传入 1 2 3，如果是 4 或 5 的话，拆分成两个 call
+    // type 可以传入 1 2 3 4 5。如果是 4 或 5 的话，会自动递归调用一次
     private static void CreateDisplay(int type, GameMonitor monitor)
     {
+        if (type is 4 or 5)
+        {
+            CreateDisplay(3, monitor);
+            type -= 3;
+        }
         if (type is < 1 or > 3) throw new ArgumentException("这不对吧");
+        
+        if (prefab == null)
+        {
+            MelonLogger.Error("[DisplayTouchInGame] prefab is null");
+            return;
+        }
         var sub = monitor.gameObject.transform.Find("Canvas/Sub");
         if (type == 3)
         {


### PR DESCRIPTION
之前版本代码中，`CreateDisplay`创建组件，是仅在GameProcess Onstart的时候，根据`DisplayType`的值，调用一次的。
导致如果游戏开始时玩家没有开启DisplayInTouch，那组件就不会被创建；游戏过程中按触发功能的按键，尽管`DisplayType`调成了1，但由于没有组件，所以还是显示不出来。

## Summary by Sourcery

通过在功能被切换为开启时再创建显示器，而不是只在游戏开始时创建，确保游戏内触摸显示 UI 可以在游戏开始后动态启用。

Bug Fixes:
- 修复了在游戏中途启用 `DisplayInTouch` 时不显示的问题，因为如果在游戏开始时被禁用，其 UI 组件从未被创建。

Enhancements:
- 重构显示创建逻辑，使多部件显示类型（4 和 5）都能在 `CreateDisplay` 帮助方法中得到一致的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure in-game touch display UI can be enabled dynamically after game start by creating the display when the feature is toggled on instead of only at game start.

Bug Fixes:
- Fix DisplayInTouch not appearing when enabled mid-game because its UI components were never created if disabled at game start.

Enhancements:
- Refactor display creation logic so multi-part display types (4 and 5) are consistently handled inside the CreateDisplay helper.

</details>