### PR TITLE
feat:虚拟投币，支持按键和网络请求投币

### DIFF
--- a/AquaMai.Config/Types/KeyCodeOrName.cs
+++ b/AquaMai.Config/Types/KeyCodeOrName.cs
@@ -54,4 +54,7 @@ public enum KeyCodeOrName
     CustomFn2,
     CustomFn3,
     CustomFn4,
+    
+    Equals = 100, // 这里的100是为了预留未来的添加空间的。后面新增的枚举值一律在100后面依次排列
+    // 注：出于配置向前兼容性起见，新增的key请一律放在最下方，避免破坏上面已经有的键的枚举值
 }

--- a/AquaMai.Core/Helpers/KeyListener.cs
+++ b/AquaMai.Core/Helpers/KeyListener.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using AquaMai.Config.Types;
@@ -59,7 +59,7 @@ public static class KeyListener
             KeyCodeOrName.Select1P => InputManager.GetButtonPush(0, InputManager.ButtonSetting.Select),
             KeyCodeOrName.Select2P => InputManager.GetButtonPush(1, InputManager.ButtonSetting.Select),
             <= KeyCodeOrName.CustomFn4 => _customFnState[key - KeyCodeOrName.CustomFn1],
-            _ => throw new ArgumentOutOfRangeException(nameof(key), key, "我也不知道这是什么键")
+            _ => Input.GetKey(key.GetKeyCode()) // 添加在枚举末尾的“新增键盘支持键”
         };
 
     // 获得按键是否被短按（会在按键被抬起的那一帧触发）
@@ -153,6 +153,7 @@ public static class KeyListener
             KeyCodeOrName.DownArrow => KeyCode.DownArrow,
             KeyCodeOrName.LeftArrow => KeyCode.LeftArrow,
             KeyCodeOrName.RightArrow => KeyCode.RightArrow,
+            KeyCodeOrName.Equals => KeyCode.Equals,
             _ => throw new ArgumentOutOfRangeException(nameof(keyCodeOrName), keyCodeOrName, "游戏功能键需要单独处理")
         };
 }

--- a/AquaMai.Mods/GameSystem/VirtualCoin.cs
+++ b/AquaMai.Mods/GameSystem/VirtualCoin.cs
@@ -1,0 +1,511 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using AMDaemon;
+using AquaMai.Config.Attributes;
+using AquaMai.Config.Types;
+using AquaMai.Core.Attributes;
+using HarmonyLib;
+using Mai2.Mai2Cue;
+using Main;
+using Manager;
+using MelonLoader;
+using Process;
+using UnityEngine;
+using Credit = AMDaemon.Credit;
+using Input = UnityEngine.Input;
+using Type = System.Type;
+
+
+namespace AquaMai.Mods.GameSystem;
+
+[ConfigSection(
+    "虚拟投币",
+    zh: """
+        在不依赖 SegaTools 的前提下实现的投币功能
+        支持通过键盘按键或 HTTP 接口远程增加点数
+        注意:该功能增加的点数游戏重启后不会保存
+        """,
+    en: """
+        Implements a custom Credit system without relying on SegaTools
+        Supports adding Credits via keyboard input or remotely through an HTTP service
+        Note: Credits added by this feature are not persisted and will be reset after restarting the game
+        """)]
+public static class VirtualCoin
+{
+    [ConfigEntry(
+        "启用键盘按键",
+        """
+        Adding Credits via keyboard input.
+        """,
+        """
+        使用键盘按键增加点数
+        """)]
+    private static readonly bool IsUseKeyboard = true;
+
+    [ConfigEntry(
+        "绑定按键",
+        """
+        Bind keyboard.
+        """,
+        """
+        绑定使用的键盘按键
+        """)]
+    public static readonly KeyCodeID CoinKey = (KeyCodeID)35;
+
+    [ConfigEntry(
+        "启用远程投币",
+        """
+        Remotely add Credits via an HTTP interface.
+        """,
+        """
+        通过 HTTP 接口远程增加点数
+        """)]
+    private static readonly bool IsUseRemote = false;
+
+    [ConfigEntry(
+        "监听端口",
+        """
+        Listening port for the HTTP service.
+        """,
+        """
+        HTTP服务监听的端口
+        """)]
+    private static readonly int Prot = 7654;
+
+    [ConfigEntry(
+        "密码验证",
+        """
+        Enable password verification for the HTTP service. leave it blank to skip.When requesting, the url contains '?password='
+        """,
+        """
+        设置访问密码,留空不使用,请求的时候url带'?password='
+        """)]
+    private static readonly string Password = "";
+
+    [ConfigEntry(
+        "启用音效",
+        """
+        Play Sound Effects.
+        """,
+        """
+        是否播放音效
+        """)]
+    private static readonly bool IsPlaySound = true;
+
+    private static int _bufferCredit = 0;
+
+    private static bool _isFieldSuccess = false;
+
+    //缓存以提升性能
+    private static IntPtr Pointer;
+
+    private static MethodInfo call_Method;
+
+    private static MethodInfo creditUnit_isGameCostEnough_Method;
+
+    private static MethodInfo creditUnit_payGameCost_Method;
+
+    public static void OnAfterPatch()
+    {
+        if (IsUseRemote)
+        {
+            CreditHttpServerHost.StartOnce();
+            MelonModLogger.Msg("[VirtualCoin] HTTP Server started: " +
+                               (CreditHttpServerHost.IsRunning ? $"Success on {Prot}" : "Failed"));
+        }
+    }
+
+    //该功能实现实际上很简单，就是整一个缓存点数，扣Credit的时候优先扣缓存中的Credit，然后不够再交给原逻辑
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(CreditUnit), "Credit", MethodType.Getter)]
+    public static void CreditPatch(ref uint __result)
+    {
+        __result += (uint)_bufferCredit;
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(CreditUnit), "IsZero", MethodType.Getter)]
+    public static void IsZorePatch(ref bool __result)
+    {
+        __result = __result && _bufferCredit == 0;
+    }
+
+    public static int GetNeedCost(CreditUnit __instance, int gameCostIndex, int count)
+    {
+        var gameCosts = __instance.GameCosts;
+        if (gameCosts == null)
+        {
+            throw new Exception("Failed to get GameCosts value");
+        }
+
+        var needCost = count * (int)gameCosts[gameCostIndex];
+
+# if DEBUG
+        MelonLogger.Msg($"NeedCost:{needCost} Credits.");
+# endif
+
+        return needCost;
+    }
+
+    public static IntPtr GetPointer(CreditUnit __instance)
+    {
+        var pointerProp = AccessTools.Property(typeof(CreditUnit), "Pointer");
+        if (pointerProp == null)
+        {
+            throw new Exception("Failed to access Pointer property");
+        }
+
+        var pointerValue = pointerProp.GetValue(__instance);
+        if (pointerValue == null)
+        {
+            throw new Exception("Failed to get Pointer value");
+        }
+
+        return (IntPtr)pointerValue;
+    }
+
+    public static MethodInfo GetAPIMethod(string apiName, params Type[] parameterTypes)
+    {
+        var apiType = AccessTools.TypeByName("AMDaemon.Api");
+        if (apiType == null)
+            throw new Exception("Failed to access AMDaemon.Api type");
+
+        if (apiName == "Call")
+        {
+            var methods = apiType.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(m => m.Name == "Call" && m.GetParameters().Length == 1)
+                .ToArray();
+
+            // 1.优先匹配非泛型: bool Call(Func<bool>)
+            var nonGenericBool = methods.FirstOrDefault(m =>
+                !m.IsGenericMethodDefinition &&
+                m.ReturnType == typeof(bool) &&
+                m.GetParameters()[0].ParameterType == typeof(Func<bool>));
+
+            if (nonGenericBool != null)
+                return nonGenericBool;
+
+            // 2.兼容泛型: T Call<T>(Func<T>) 闭包成 bool
+            var genericDef = methods.FirstOrDefault(m =>
+                m.IsGenericMethodDefinition &&
+                m.GetGenericArguments().Length == 1 &&
+                m.GetParameters()[0].ParameterType.IsGenericType &&
+                m.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(Func<>));
+
+            if (genericDef != null)
+                return genericDef.MakeGenericMethod(typeof(bool));
+
+            var overloads = string.Join(" | ", methods.Select(m => m.ToString()));
+            throw new Exception("Failed to access Api.Call(Func<bool>) method. Overloads: " + overloads);
+        }
+
+        MethodInfo calledMethod;
+        if (parameterTypes != null && parameterTypes.Length > 0)
+            calledMethod = AccessTools.Method(apiType, apiName, parameterTypes);
+        else
+            calledMethod = AccessTools.Method(apiType, apiName);
+
+        if (calledMethod == null)
+            throw new Exception($"Failed to access Api.{apiName} method");
+
+        return calledMethod;
+    }
+
+
+
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(CreditUnit), "IsGameCostEnough", new Type[] { typeof(int), typeof(int) })]
+    public static bool IsGameCostEnough(CreditUnit __instance, ref bool __result, int gameCostIndex, int count)
+    {
+        try
+        {
+            var needCost = GetNeedCost(__instance, gameCostIndex, count);
+            if (_bufferCredit >= needCost)
+            {
+                __result = true;
+                return false;
+            }
+            else if (_bufferCredit != 0 && _bufferCredit < needCost)
+            {
+                needCost -= (int)_bufferCredit;
+                if (call_Method == null)
+                {
+                    call_Method = GetAPIMethod("Call");
+                }
+
+                if (creditUnit_isGameCostEnough_Method == null)
+                {
+                    creditUnit_isGameCostEnough_Method = GetAPIMethod("CreditUnit_isGameCostEnough");
+                }
+
+                Func<bool> lambda = () =>
+                    (bool)creditUnit_payGameCost_Method.Invoke(null, new object[] { GetPointer(__instance), 0, (int)needCost });
+                __result = (bool)call_Method.Invoke(null, new object[] { lambda });
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception e)
+        {
+            MelonLogger.Warning("[VirtualCoin]Patch IsGameCostEnough Failed:" + e.Message);
+            return true;
+        }
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(CreditUnit), "PayGameCost", new Type[] { typeof(int), typeof(int) })]
+    public static bool PayGameCostPatch(CreditUnit __instance, ref bool __result, int gameCostIndex, int count)
+    {
+        try
+        {
+            var needCost = (uint)GetNeedCost(__instance, gameCostIndex, count);
+            if (_bufferCredit - needCost >= 0)
+            {
+                _bufferCredit -= (int)needCost;
+
+# if DEBUG
+                MelonLogger.Msg($"#1:_buffer:{_bufferCredit}");
+# endif
+
+                return false;
+            }
+
+            if (_bufferCredit > 0 && _bufferCredit - needCost < 0)
+            {
+                needCost -= (uint)_bufferCredit;
+                _bufferCredit = 0;
+
+# if DEBUG
+                MelonLogger.Msg($"#2:_buffer:{_bufferCredit};needCost:{needCost}");
+# endif
+
+                if (call_Method == null)
+                {
+                    call_Method = GetAPIMethod("Call");
+                }
+                if (creditUnit_payGameCost_Method == null)
+                {
+                    creditUnit_payGameCost_Method = GetAPIMethod("CreditUnit_payGameCost");
+                }
+
+                Func<bool> lambda = () =>
+                    (bool)creditUnit_payGameCost_Method.Invoke(null, new object[] { GetPointer(__instance), 0, (int)needCost });
+                __result = (bool)call_Method.Invoke(null, new object[] { lambda });
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception e)
+        {
+            MelonLogger.Warning("[VirtualCoin]Patch PayGameCost Failed" + e.Message);
+            return true;
+        }
+    }
+
+    [EnableIf(nameof(IsUseKeyboard))]
+    [HarmonyPatch(typeof(GameMainObject), "Update")]
+    [HarmonyPostfix]
+    public static void OnUpdatePatch()
+    {
+        if (Input.GetKeyDown(getKeyCode(CoinKey)))
+        {
+            _bufferCredit += 1;
+            if (IsPlaySound)
+            {
+                SoundManager.PlaySystemSE(Cue.SE_SYS_CREDIT);
+            }
+        }
+    }
+
+    private static KeyCode getKeyCode(KeyCodeID keyCodeID)
+    {
+        try
+        {
+            return (KeyCode)Enum.Parse(typeof(KeyCode), keyCodeID.ToString());
+        }
+        catch (Exception)
+        {
+            return KeyCode.Equals;
+        }
+    }
+
+    private static class CreditHttpServerHost
+    {
+        private static readonly object StartSync = new object();
+
+        private static HttpListener _listener;
+
+        private static Thread _listenThread;
+
+        private static volatile bool _running;
+
+        public static bool IsRunning => _running;
+
+        public static void StartOnce()
+        {
+            if (_running)
+            {
+                return;
+            }
+
+            lock (StartSync)
+            {
+                if (_running)
+                {
+                    return;
+                }
+
+                try
+                {
+                    var port = GetPort();
+                    _listener = new HttpListener();
+                    _listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+                    _listener.Start();
+
+                    _running = true;
+                    _listenThread = new Thread(ListenLoop)
+                    {
+                        IsBackground = true,
+                        Name = "AMDaemon.CreditHttpServer"
+                    };
+                    _listenThread.Start();
+                }
+                catch
+                {
+                    _running = false;
+                    try
+                    {
+                        _listener?.Close();
+                    }
+                    catch
+                    {
+                    }
+
+                    _listener = null;
+                }
+            }
+        }
+
+        private static int GetPort()
+        {
+            if (Prot > 0 && Prot <= 65535)
+            {
+                return Prot;
+            }
+
+            return 6543;
+        }
+
+        private static void ListenLoop()
+        {
+            while (_running && _listener != null)
+            {
+                HttpListenerContext context;
+                try
+                {
+                    context = _listener.GetContext();
+                }
+                catch
+                {
+                    break;
+                }
+
+                try
+                {
+                    HandleRequest(context);
+                }
+                catch
+                {
+                    WriteJson(context.Response, 500, "{\"ok\":false,\"error\":\"internal_error\"}");
+                }
+            }
+        }
+
+        private static void HandleRequest(HttpListenerContext context)
+        {
+            var path = context.Request.Url?.AbsolutePath ?? "/";
+
+            if (string.Equals(path, "/", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(path, "/health", StringComparison.OrdinalIgnoreCase))
+            {
+                WriteJson(context.Response, 200, "{\"ok\":true,\"service\":[\"credit\",\"add\"]}");
+                return;
+            }
+
+            if (string.Equals(path, "/credit", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!CheckPassword(context.Request))
+                {
+                    WriteJson(context.Response, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
+                    return;
+                }
+
+                uint credit = 0;
+                uint amDcredit = 0;
+                uint remain = 0;
+                uint bufferCredit = 0;
+                var freePlay = false;
+
+                var player = Credit.Players[0];
+                bufferCredit = (uint)_bufferCredit;
+                credit = player.Credit;
+                amDcredit = credit - (uint)bufferCredit;
+                remain = player.Remain;
+                freePlay = player.IsFreePlay;
+                WriteJson(context.Response, 200,
+                    "{\"ok\":true,\"bufferCredit\":" + bufferCredit + ",\"Credit\":" + credit + ",\"AMDCredit\":" +
+                    amDcredit + ",\"remain\":" + remain + ",\"isFreePlay\":" + (freePlay ? "true" : "false") + "}");
+                return;
+            }
+
+            if (string.Equals(path, "/add", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!CheckPassword(context.Request))
+                {
+                    WriteJson(context.Response, 401, "{\"ok\":false,\"error\":\"unauthorized\"}");
+                    return;
+                }
+
+                _bufferCredit += 1;
+                if (IsPlaySound)
+                {
+                    SoundManager.PlaySystemSE(Cue.SE_SYS_CREDIT);
+                }
+
+                WriteJson(context.Response, 200, "{\"ok\":true,\"bufferCredit\":" + _bufferCredit + "}");
+                return;
+            }
+
+            WriteJson(context.Response, 404, "{\"ok\":false,\"error\":\"not_found\"}");
+        }
+
+        private static void WriteJson(HttpListenerResponse response, int statusCode, string payload)
+        {
+            response.StatusCode = statusCode;
+            response.ContentType = "application/json; charset=utf-8";
+            var bytes = Encoding.UTF8.GetBytes(payload);
+            response.ContentLength64 = bytes.LongLength;
+            using var stream = response.OutputStream;
+            stream.Write(bytes, 0, bytes.Length);
+        }
+
+        private static bool CheckPassword(HttpListenerRequest request)
+        {
+            if (string.IsNullOrEmpty(Password))
+            {
+                return true; // skip
+            }
+
+            var input = request.QueryString["password"];
+            return string.Equals(input, Password, StringComparison.Ordinal);
+        }
+    }
+}

--- a/AquaMai.Mods/GameSystem/VirtualCoin.cs
+++ b/AquaMai.Mods/GameSystem/VirtualCoin.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Reflection;
@@ -8,15 +10,13 @@ using AMDaemon;
 using AquaMai.Config.Attributes;
 using AquaMai.Config.Types;
 using AquaMai.Core.Attributes;
+using AquaMai.Core.Helpers;
 using HarmonyLib;
 using Mai2.Mai2Cue;
 using Main;
 using Manager;
 using MelonLoader;
-using Process;
-using UnityEngine;
 using Credit = AMDaemon.Credit;
-using Input = UnityEngine.Input;
 using Type = System.Type;
 
 
@@ -25,44 +25,43 @@ namespace AquaMai.Mods.GameSystem;
 [ConfigSection(
     "虚拟投币",
     zh: """
-        在不依赖 SegaTools 的前提下实现的投币功能
-        支持通过键盘按键或 HTTP 接口远程增加点数
+        基于Mod，在不依赖 SegaTools 的前提下实现的投币功能
+        支持通过键盘按键、机台上自定义功能键或 HTTP 接口远程增加点数
         注意:该功能增加的点数游戏重启后不会保存
         """,
     en: """
         Implements a custom Credit system without relying on SegaTools
-        Supports adding Credits via keyboard input or remotely through an HTTP service
+        Supports adding Credits via keyboard input, cabinet custom FN key or remotely through an HTTP service
         Note: Credits added by this feature are not persisted and will be reset after restarting the game
         """)]
 public static class VirtualCoin
 {
     [ConfigEntry(
-        "启用键盘按键",
+        "投币按键",
         """
-        Adding Credits via keyboard input.
+        Bind a key for add a credit (Keyboard key or cabinet custom FN key)
         """,
         """
-        使用键盘按键增加点数
+        绑定使用的投币按键（键盘按键或自定义功能键均可）
         """)]
-    private static readonly bool IsUseKeyboard = true;
-
+    public static readonly KeyCodeOrName CoinKey = KeyCodeOrName.Equals;
+    
     [ConfigEntry(
-        "绑定按键",
-        """
-        Bind keyboard.
-        """,
-        """
-        绑定使用的键盘按键
-        """)]
-    public static readonly KeyCodeID CoinKey = (KeyCodeID)35;
+        "长按",
+        "Should long press to trigger",
+        "是否长按上述按键才能触发"
+        )]
+    public static readonly bool LongPress = false;
 
     [ConfigEntry(
         "启用远程投币",
         """
         Remotely add Credits via an HTTP interface.
+        Warning: If you enable this option, an HTTP server will listen on 0.0.0.0 on your machine (the port is specified by the option below). Please be mindful of security risks and consider using password authentication.
         """,
         """
-        通过 HTTP 接口远程增加点数
+        通过 HTTP 接口远程增加点数。
+        警告：若开启此项，则会在您机器的0.0.0.0上监听一个HTTP服务器（端口号由下面选项指定）。请注意安全性问题，并考虑配合密码验证。
         """)]
     private static readonly bool IsUseRemote = false;
 
@@ -79,10 +78,10 @@ public static class VirtualCoin
     [ConfigEntry(
         "密码验证",
         """
-        Enable password verification for the HTTP service. leave it blank to skip.When requesting, the url contains '?password='
+        Enable password verification for the HTTP service, or leave it blank to disable password verification. If enabled, the requests should be with query param '?password='
         """,
         """
-        设置访问密码,留空不使用,请求的时候url带'?password='
+        设置访问密码，留空则不使用密码。如果使用密码，请求时URL后应当追加参数'?password='
         """)]
     private static readonly string Password = "";
 
@@ -96,9 +95,9 @@ public static class VirtualCoin
         """)]
     private static readonly bool IsPlaySound = true;
 
-    private static int _bufferCredit = 0;
+    private static bool IsUseKeyboard => CoinKey != KeyCodeOrName.None;
 
-    private static bool _isFieldSuccess = false;
+    private static int _bufferCredit = 0;
 
     //缓存以提升性能
     private static IntPtr Pointer;
@@ -114,13 +113,10 @@ public static class VirtualCoin
         if (IsUseRemote)
         {
             CreditHttpServerHost.StartOnce();
-            MelonLogger.Msg("[VirtualCoin] HTTP Server started: " +
-                               (CreditHttpServerHost.IsRunning ? $"Success on {Port}" : "Failed"));
         }
     }
 
     //该功能实现实际上很简单，就是整一个缓存点数，扣Credit的时候优先扣缓存中的Credit，然后不够再交给原逻辑
-
     [HarmonyPostfix]
     [HarmonyPatch(typeof(CreditUnit), "Credit", MethodType.Getter)]
     public static void CreditPatch(ref uint __result)
@@ -130,12 +126,12 @@ public static class VirtualCoin
 
     [HarmonyPostfix]
     [HarmonyPatch(typeof(CreditUnit), "IsZero", MethodType.Getter)]
-    public static void IsZorePatch(ref bool __result)
+    public static void IsZeroPatch(ref bool __result)
     {
         __result = __result && _bufferCredit == 0;
     }
 
-    public static int GetNeedCost(CreditUnit __instance, int gameCostIndex, int count)
+    private static int GetNeedCost(CreditUnit __instance, int gameCostIndex, int count)
     {
         var gameCosts = __instance.GameCosts;
         if (gameCosts == null)
@@ -144,15 +140,10 @@ public static class VirtualCoin
         }
 
         var needCost = count * (int)gameCosts[gameCostIndex];
-
-# if DEBUG
-        MelonLogger.Msg($"NeedCost:{needCost} Credits.");
-# endif
-
         return needCost;
     }
 
-    public static IntPtr GetPointer(CreditUnit __instance)
+    private static IntPtr GetPointer(CreditUnit __instance)
     {
         var pointerProp = AccessTools.Property(typeof(CreditUnit), "Pointer");
         if (pointerProp == null)
@@ -169,7 +160,7 @@ public static class VirtualCoin
         return (IntPtr)pointerValue;
     }
 
-    public static MethodInfo GetAPIMethod(string apiName, params Type[] parameterTypes)
+    private static MethodInfo GetAPIMethod(string apiName, params Type[] parameterTypes)
     {
         var apiType = AccessTools.TypeByName("AMDaemon.Api");
         if (apiType == null)
@@ -316,25 +307,13 @@ public static class VirtualCoin
     [HarmonyPostfix]
     public static void OnUpdatePatch()
     {
-        if (Input.GetKeyDown(getKeyCode(CoinKey)))
+        if (KeyListener.GetKeyDownOrLongPress(CoinKey, LongPress))
         {
             _bufferCredit += 1;
             if (IsPlaySound)
             {
                 SoundManager.PlaySystemSE(Cue.SE_SYS_CREDIT);
             }
-        }
-    }
-
-    private static KeyCode getKeyCode(KeyCodeID keyCodeID)
-    {
-        try
-        {
-            return (KeyCode)Enum.Parse(typeof(KeyCode), keyCodeID.ToString());
-        }
-        catch (Exception)
-        {
-            return KeyCode.Equals;
         }
     }
 
@@ -347,8 +326,6 @@ public static class VirtualCoin
         private static Thread _listenThread;
 
         private static volatile bool _running;
-
-        public static bool IsRunning => _running;
 
         public static void StartOnce()
         {
@@ -368,20 +345,22 @@ public static class VirtualCoin
                 {
                     var port = GetPort();
                     _listener = new HttpListener();
-                    _listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+                    _listener.Prefixes.Add($"http://*:{port}/");
                     _listener.Start();
 
                     _running = true;
                     _listenThread = new Thread(ListenLoop)
                     {
                         IsBackground = true,
-                        Name = "AMDaemon.CreditHttpServer"
+                        Name = "AquaMai.VirtualCoin.CreditHttpServer"
                     };
                     _listenThread.Start();
+                    MelonLogger.Msg($"[VirtualCoin] HTTP Server started: Success on {port}");
                 }
-                catch
+                catch (Exception e)
                 {
                     _running = false;
+                    MelonLogger.Error($"[VirtualCoin] HTTP Server started Failed: {e}");
                     try
                     {
                         _listener?.Close();
@@ -402,7 +381,7 @@ public static class VirtualCoin
                 return Port;
             }
 
-            return 6543;
+            return 7654;
         }
 
         private static void ListenLoop()

--- a/AquaMai.Mods/GameSystem/VirtualCoin.cs
+++ b/AquaMai.Mods/GameSystem/VirtualCoin.cs
@@ -274,6 +274,7 @@ public static class VirtualCoin
                 MelonLogger.Msg($"#1:_buffer:{_bufferCredit}");
 # endif
 
+                __result = true;
                 return false;
             }
 

--- a/AquaMai.Mods/GameSystem/VirtualCoin.cs
+++ b/AquaMai.Mods/GameSystem/VirtualCoin.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using AMDaemon;
@@ -466,7 +467,23 @@ public static class VirtualCoin
             }
 
             var input = request.QueryString["password"];
-            return string.Equals(input, Password, StringComparison.Ordinal);
+            return FixedTimeEquals(input, Password);
+        }
+        
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        private static bool FixedTimeEquals(string left, string right)
+        {
+            if (left == null || right == null) return false;
+            if (left.Length != right.Length) return false;
+
+            int result = 0;
+            for (int i = 0; i < left.Length; i++)
+            {
+                // 使用按位或，只要有一处不等，result 就会变成非零值
+                result |= left[i] ^ right[i];
+            }
+
+            return result == 0;
         }
     }
 }

--- a/AquaMai.Mods/GameSystem/VirtualCoin.cs
+++ b/AquaMai.Mods/GameSystem/VirtualCoin.cs
@@ -97,16 +97,13 @@ public static class VirtualCoin
 
     private static bool IsUseKeyboard => CoinKey != KeyCodeOrName.None;
 
-    private static int _bufferCredit = 0;
+    // 出于线程安全，下面变量应该仅在Unity主线程写入（通过MelonCoroutine.Start等方式）。其他线程只能读，不应写入。
+    private static volatile int _bufferCredit = 0;
 
     //缓存以提升性能
-    private static IntPtr Pointer;
+    private static PropertyInfo pointerProp;
 
-    private static MethodInfo call_Method;
-
-    private static MethodInfo creditUnit_isGameCostEnough_Method;
-
-    private static MethodInfo creditUnit_payGameCost_Method;
+    private static Dictionary<string, MethodInfo> methods = new();
 
     public static void OnAfterPatch()
     {
@@ -145,13 +142,8 @@ public static class VirtualCoin
 
     private static IntPtr GetPointer(CreditUnit __instance)
     {
-        var pointerProp = AccessTools.Property(typeof(CreditUnit), "Pointer");
-        if (pointerProp == null)
-        {
-            throw new Exception("Failed to access Pointer property");
-        }
-
-        var pointerValue = pointerProp.GetValue(__instance);
+        if (pointerProp == null) pointerProp = AccessTools.Property(typeof(CreditUnit), "Pointer");
+        var pointerValue = pointerProp?.GetValue(__instance);
         if (pointerValue == null)
         {
             throw new Exception("Failed to get Pointer value");
@@ -207,8 +199,14 @@ public static class VirtualCoin
         return calledMethod;
     }
 
-
-
+    private static bool CallAPIMethod(string methodName, object[] arguments)
+    {
+        if (!methods.ContainsKey("Call")) methods["Call"] = GetAPIMethod("Call");
+        if (!methods.ContainsKey(methodName)) methods[methodName] = GetAPIMethod(methodName);
+        
+        Func<bool> lambda = () => (bool)methods[methodName].Invoke(null, arguments);
+        return (bool)methods["Call"].Invoke(null, [lambda]);
+    }
 
     [HarmonyPrefix]
     [HarmonyPatch(typeof(CreditUnit), "IsGameCostEnough", new Type[] { typeof(int), typeof(int) })]
@@ -224,20 +222,8 @@ public static class VirtualCoin
             }
             else if (_bufferCredit != 0 && _bufferCredit < needCost)
             {
-                needCost -= (int)_bufferCredit;
-                if (call_Method == null)
-                {
-                    call_Method = GetAPIMethod("Call");
-                }
-
-                if (creditUnit_isGameCostEnough_Method == null)
-                {
-                    creditUnit_isGameCostEnough_Method = GetAPIMethod("CreditUnit_isGameCostEnough");
-                }
-
-                Func<bool> lambda = () =>
-                    (bool)creditUnit_isGameCostEnough_Method.Invoke(null, new object[] { GetPointer(__instance), 0, (int)needCost });
-                __result = (bool)call_Method.Invoke(null, new object[] { lambda });
+                needCost -= _bufferCredit;
+                __result = CallAPIMethod("CreditUnit_isGameCostEnough", [GetPointer(__instance), 0, needCost]);
                 return false;
             }
 
@@ -256,7 +242,7 @@ public static class VirtualCoin
     {
         try
         {
-            var needCost = (uint)GetNeedCost(__instance, gameCostIndex, count);
+            var needCost = GetNeedCost(__instance, gameCostIndex, count);
             if (_bufferCredit - needCost >= 0)
             {
                 _bufferCredit -= (int)needCost;
@@ -271,25 +257,13 @@ public static class VirtualCoin
 
             if (_bufferCredit > 0 && _bufferCredit - needCost < 0)
             {
-                needCost -= (uint)_bufferCredit;
+                needCost -= _bufferCredit;
                 _bufferCredit = 0;
 
 # if DEBUG
                 MelonLogger.Msg($"#2:_buffer:{_bufferCredit};needCost:{needCost}");
 # endif
-
-                if (call_Method == null)
-                {
-                    call_Method = GetAPIMethod("Call");
-                }
-                if (creditUnit_payGameCost_Method == null)
-                {
-                    creditUnit_payGameCost_Method = GetAPIMethod("CreditUnit_payGameCost");
-                }
-
-                Func<bool> lambda = () =>
-                    (bool)creditUnit_payGameCost_Method.Invoke(null, new object[] { GetPointer(__instance), 0, (int)needCost });
-                __result = (bool)call_Method.Invoke(null, new object[] { lambda });
+                __result = CallAPIMethod("CreditUnit_payGameCost", [GetPointer(__instance), 0, (int)needCost]);
                 return false;
             }
 
@@ -434,6 +408,8 @@ public static class VirtualCoin
                 uint bufferCredit = 0;
                 var freePlay = false;
 
+                // 对下列的信息，可以不做多线程保护，因为是只读的、而且变量之间相互没有依赖，
+                // 而且这只是一个信息性质的GET接口、对实时性没有要求，所以直接只读访问变量问题不大。
                 var player = Credit.Players[0];
                 bufferCredit = (uint)_bufferCredit;
                 credit = player.Credit;
@@ -454,17 +430,22 @@ public static class VirtualCoin
                     return;
                 }
 
-                _bufferCredit += 1;
-                if (IsPlaySound)
-                {
-                    SoundManager.PlaySystemSE(Cue.SE_SYS_CREDIT);
-                }
-
-                WriteJson(context.Response, 200, "{\"ok\":true,\"bufferCredit\":" + _bufferCredit + "}");
+                MelonCoroutines.Start(AddCredit());
+                WriteJson(context.Response, 200, "{\"ok\":true}");
                 return;
             }
 
             WriteJson(context.Response, 404, "{\"ok\":false,\"error\":\"not_found\"}");
+        }
+        
+        private static IEnumerator AddCredit()
+        {
+            _bufferCredit += 1;
+            if (IsPlaySound)
+            {
+                SoundManager.PlaySystemSE(Cue.SE_SYS_CREDIT);
+            }
+            yield return true;
         }
 
         private static void WriteJson(HttpListenerResponse response, int statusCode, string payload)

--- a/AquaMai.Mods/GameSystem/VirtualCoin.cs
+++ b/AquaMai.Mods/GameSystem/VirtualCoin.cs
@@ -74,7 +74,7 @@ public static class VirtualCoin
         """
         HTTP服务监听的端口
         """)]
-    private static readonly int Prot = 7654;
+    private static readonly int Port = 7654;
 
     [ConfigEntry(
         "密码验证",
@@ -114,8 +114,8 @@ public static class VirtualCoin
         if (IsUseRemote)
         {
             CreditHttpServerHost.StartOnce();
-            MelonModLogger.Msg("[VirtualCoin] HTTP Server started: " +
-                               (CreditHttpServerHost.IsRunning ? $"Success on {Prot}" : "Failed"));
+            MelonLogger.Msg("[VirtualCoin] HTTP Server started: " +
+                               (CreditHttpServerHost.IsRunning ? $"Success on {Port}" : "Failed"));
         }
     }
 
@@ -245,7 +245,7 @@ public static class VirtualCoin
                 }
 
                 Func<bool> lambda = () =>
-                    (bool)creditUnit_payGameCost_Method.Invoke(null, new object[] { GetPointer(__instance), 0, (int)needCost });
+                    (bool)creditUnit_isGameCostEnough_Method.Invoke(null, new object[] { GetPointer(__instance), 0, (int)needCost });
                 __result = (bool)call_Method.Invoke(null, new object[] { lambda });
                 return false;
             }
@@ -396,9 +396,9 @@ public static class VirtualCoin
 
         private static int GetPort()
         {
-            if (Prot > 0 && Prot <= 65535)
+            if (Port > 0 && Port <= 65535)
             {
-                return Prot;
+                return Port;
             }
 
             return 6543;

--- a/AquaMai/configSort.yaml
+++ b/AquaMai/configSort.yaml
@@ -22,6 +22,7 @@
   - GameSystem.KeyMap
   - GameSettings.TouchSensitivity
   - GameSystem.ExteraMouseInput
+  - GameSystem.VirtualCoin
 
 判定:
   - GameSettings.JudgeAdjust
@@ -174,4 +175,5 @@
   - Fancy.TrackCamouflage
   - Fancy.ResourcesOverride
   - GameSystem.OldCabLightBoardSupport
+  - GameSystem.VirtualCoin
 


### PR DESCRIPTION
该功能实现实际上很简单，就是整一个缓存Credit，扣Credit的时候优先扣缓存中的Credit，然后不够经过计算再交给原逻辑，从而绕过AMDaemon喵🐱

## Summary by Sourcery

添加一个可配置的虚拟投币系统，通过内存缓冲区和远程控制选项扩展现有的积分（credit）处理逻辑。

新功能：
- 引入 `VirtualCoin` 游戏系统模块，维护一个与现有 `CreditUnit` 逻辑集成的缓冲积分池。
- 支持通过可配置的键盘按键添加积分，并可选择是否播放标准的投币音效。
- 提供一个轻量级本地 HTTP 服务，用于远程查询和添加积分，并支持可选的密码保护。

增强内容：
- 在全局配置排序中注册 `VirtualCoin` 配置区块，以便在 UI 中正确展示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configurable virtual coin system that augments the existing credit handling with an in-memory buffer and remote control options.

New Features:
- Introduce a VirtualCoin game system module that maintains a buffered credit pool integrated with the existing CreditUnit logic.
- Support adding credits via a configurable keyboard key while optionally playing the standard credit sound effect.
- Expose a lightweight local HTTP service to query and add credits remotely, with optional password protection.

Enhancements:
- Register the VirtualCoin configuration section in the global config sort order for proper UI exposure.

</details>