### PR TITLE
fix: 修复Shim无法匹配某些版本的PacketUpsertUserAll

### DIFF
--- a/AquaMai.Core/Helpers/Shim.cs
+++ b/AquaMai.Core/Helpers/Shim.cs
@@ -189,6 +189,26 @@ public static class Shim
                 return (PacketUpsertUserAll)ctor2.Invoke(args);
             };
         }
+        else if (type.GetConstructor(new[]
+                 {
+                     typeof(int),
+                     typeof(UserData),
+                     typeof(int),
+                     typeof(Action<int>),
+                     typeof(Action<PacketStatus>)
+                 }) is ConstructorInfo ctor3)
+        {
+            return (index, src, onDone, onError) =>
+            {
+                var maxTrackNo =
+                    src.IsEntry && !Singleton<GamePlayManager>.Instance.IsEmpty()
+                        ? Singleton<GamePlayManager>.Instance.GetScoreListCount()
+                        : 0;
+
+                var args = new object[] { index, src, maxTrackNo, onDone, onError };
+                return (PacketUpsertUserAll)ctor3.Invoke(args);
+            };
+        }
         else
         {
             throw new MissingMethodException("No matching PacketUpsertUserAll constructor found");


### PR DESCRIPTION
## 由 Sourcery 提供的总结

错误修复：
- 修复了在数据包使用包含由游戏玩法状态派生的 `maxTrackNo` 参数的构造函数时，Shim 无法匹配并构造 `PacketUpsertUserAll` 的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix Shim failing to match and construct PacketUpsertUserAll when the packet uses a constructor that includes a maxTrackNo parameter derived from gameplay state.

</details>