### PR TITLE
[F] SetFade festa type not working on 1.65

### DIFF
--- a/AquaMai.Mods/Fancy/SetFade.cs
+++ b/AquaMai.Mods/Fancy/SetFade.cs
@@ -4,7 +4,6 @@ using AquaMai.Core.Helpers;
 using Process;
 using UnityEngine;
 using UnityEngine.UI;
-using System.Reflection;
 using System;
 using MelonLoader;
 
@@ -44,20 +43,21 @@ public class SetFade
         bool areSubBGsValid;
         bool isFadeTypeValid;
 
-        if (GameInfo.GameVersion != 26000)
+        subBGs[0] = Resources.Load<Sprite>("Process/ChangeScreen/Sprites/Sub_01");
+        subBGs[1] = Resources.Load<Sprite>("Process/ChangeScreen/Sprites/Sub_02");
+        areSubBGsValid = subBGs[0] != null && subBGs[1] != null;
+        isFadeTypeValid = FadeType == 0 || FadeType == 1;
+
+        // make it future proof maybe?
+        if (GameInfo.GameVersion >= 26000)
         {
-            subBGs[0] = Resources.Load<Sprite>("Process/ChangeScreen/Sprites/Sub_01");
-            subBGs[1] = Resources.Load<Sprite>("Process/ChangeScreen/Sprites/Sub_02");
-            areSubBGsValid = subBGs[0] != null && subBGs[1] != null;
-            isFadeTypeValid = FadeType == 0 || FadeType == 1;
-        }
-        else
-        {
-            subBGs[0] = Resources.Load<Sprite>("Process/ChangeScreen/Sprites/Sub_01");
-            subBGs[1] = Resources.Load<Sprite>("Process/ChangeScreen/Sprites/Sub_02");
-            subBGs[2] = Resources.Load<Sprite>("Process/ChangeScreen/Sprites/Sub_03");
-            areSubBGsValid = subBGs[0] != null && subBGs[1] != null && subBGs[2] != null;
-            isFadeTypeValid = FadeType == 0 || FadeType == 1 || FadeType == 2;
+            var festaSubBG = Resources.Load<Sprite>("Process/ChangeScreen/Sprites/Sub_03");
+            if (festaSubBG != null)
+            {
+                subBGs[2] = festaSubBG;
+                areSubBGsValid = areSubBGsValid && subBGs[2] != null;
+                isFadeTypeValid = isFadeTypeValid || FadeType == 2;
+            }
         }
 
         if (!areSubBGsValid)


### PR DESCRIPTION
## Summary by Sourcery

调整 SetFade 的初始化方式，以在较新游戏版本中支持 festa 淡入淡出类型，同时保持与现有行为的兼容性。

Bug Fixes:
- 修复在游戏版本 1.65 以及其他使用更新淡入淡出类型逻辑的版本中，festa 淡入淡出类型无法被识别的问题。

Enhancements:
- 通过同时根据游戏版本和资源可用性来控制额外 festa 背景的使用，使淡入淡出背景的加载在未来更具兼容性与扩展性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust SetFade initialization to support the festa fade type on newer game versions while remaining compatible with existing behavior.

Bug Fixes:
- Fix festa fade type not being recognized on game version 1.65 and other versions using the updated fade type logic.

Enhancements:
- Make fade background loading future-proof by gating additional festa background usage on both game version and asset availability.

</details>