### PR TITLE
fix:OneKeyEntryEnd的两个bug

### DIFF
--- a/AquaMai.Mods/UX/OneKeyEntryEnd.cs
+++ b/AquaMai.Mods/UX/OneKeyEntryEnd.cs
@@ -86,7 +86,7 @@ public class OneKeyEntryEnd
                         SharedInstances.ProcessDataContainer.processManager.AddProcess(new FadeProcess(SharedInstances.ProcessDataContainer, process.Process,
                             new UnlockMusicProcess(SharedInstances.ProcessDataContainer)));
                     }
-                    break;
+                    return; // 执行上面的AddProcess操作，会引起processList中链表中内容的改变，foreach继续遍历就会`System.InvalidOperationException: Collection was modified`. 但是反正该做的事已经做完了，所以直接return就好
             }
         }
 
@@ -97,4 +97,16 @@ public class OneKeyEntryEnd
                 new MusicSelectProcess(SharedInstances.ProcessDataContainer)));
         }
     }
+    
+    [EnableGameVersion(26500, noWarn: true)]
+    [HarmonyPatch(typeof(NetDataManager), "GetGuestLogId")]
+    [HarmonyFinalizer]
+    public static Exception GetGuestLogIdFix(Exception __exception, ref ulong __result)
+    {
+        // 如果在游客模式下，一首歌都没打就跳关了：
+        // NetDataManager.GetGuestLogId中会调用Singleton<GamePlayManager>.Instance.GetGameScore，这个函数查不到对应的GameScoreList对象，就会返回null；于是就NPE了
+        // 我们则捕获这里的异常，返回数字0（这正是1.60之前的行为）
+        if (__exception != null) __result = 0L;
+        return null; 
+    } 
 }


### PR DESCRIPTION
1. 在1.65以上，如果开游客模式、一首歌不打直接结束PC，游戏会直接崩溃。由1.65新增的NetDataManager.GetGuestLogId函数引起。
   - `NetDataManager.GetGuestLogId`（1.65新增的函数）中会调用`Singleton<GamePlayManager>.Instance.GetGameScore`，由于一首歌都没打，`GetGameScore`函数查不到对应的GameScoreList对象，就会返回null
   - 接下来`GetGuestLogId`会直接使用`GetGameScore`所返回的结果，于是就NPE了
    - 解决方法：通过HarmonyFinalizer捕获这里的异常，返回数字0（这正是1.60之前的行为）
2. `DoQuickSkip`调用AddProcess、尝试结束PC后，没有立即跳出循环，造成迭代器继续遍历时抛异常。
    - 是一个轻微bug，不影响任何功能，只是会在控制台打印出一行Error不好看：`System.InvalidOperationException: Collection was modified; enumeration operation may not execute.`

## 由 Sourcery 提供的总结

修复在特定条件下跳过或结束播放时发生的 OneKeyEntryEnd 崩溃和错误。

错误修复：
- 通过在出错时将 guest 日志 ID 默认设为 0，防止在未播放任何歌曲就结束 guest 会话时，`NetDataManager.GetGuestLogId` 发生崩溃。
- 在调度结束流程的转换后立刻退出流程迭代循环，防止 `DoQuickSkip` 抛出集合在枚举期间被修改的异常。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix OneKeyEntryEnd crashes and errors when skipping or ending play under specific conditions.

Bug Fixes:
- Prevent NetDataManager.GetGuestLogId from crashing when ending a guest session without having played any songs by defaulting the guest log ID to 0 on error.
- Stop DoQuickSkip from throwing a collection-modified enumeration exception by exiting the process iteration loop immediately after scheduling the end-process transition.

</details>