### PR TITLE
fix: 一键登录时移动 CREDIT(S) 到副屏

### DIFF
--- a/AquaMai.Mods/UX/OneKeyEntryEnd.cs
+++ b/AquaMai.Mods/UX/OneKeyEntryEnd.cs
@@ -93,8 +93,8 @@ public class OneKeyEntryEnd
         if (processToRelease != null)
         {
             GameManager.SetMaxTrack();
-            // 消息ID 30001 代表隐藏 _creditContoroller (Typo in Assembly-CSharp)
-            SharedInstances.ProcessDataContainer.processManager.SendMessage(new Message(ProcessType.CommonProcess, 30001));
+            // 将 CreditController 移动到副屏
+            SharedInstances.ProcessDataContainer.processManager.SendMessage(new Message(ProcessType.CommonProcess, CommonProcess.MessageID_CreditSub));
             SharedInstances.ProcessDataContainer.processManager.AddProcess(new FadeProcess(SharedInstances.ProcessDataContainer, processToRelease,
                 new MusicSelectProcess(SharedInstances.ProcessDataContainer)));
         }

--- a/AquaMai.Mods/UX/OneKeyEntryEnd.cs
+++ b/AquaMai.Mods/UX/OneKeyEntryEnd.cs
@@ -93,6 +93,8 @@ public class OneKeyEntryEnd
         if (processToRelease != null)
         {
             GameManager.SetMaxTrack();
+            // 消息ID 30001 代表隐藏 _creditContoroller (Typo in Assembly-CSharp)
+            SharedInstances.ProcessDataContainer.processManager.SendMessage(new Message(ProcessType.CommonProcess, 30001));
             SharedInstances.ProcessDataContainer.processManager.AddProcess(new FadeProcess(SharedInstances.ProcessDataContainer, processToRelease,
                 new MusicSelectProcess(SharedInstances.ProcessDataContainer)));
         }


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 确保在使用一键登录/快速进入时隐藏积分显示，使界面行为与正常进入时保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the credit display is hidden when using one-key login/quick entry so the UI matches normal entry behavior.

</details>