### PR TITLE
[F] OneKeyRetrySkip导致的一键跳关，不会设置TrackSkip Flag的问题

### DIFF
--- a/AquaMai.Mods/UX/OneKeyRetrySkip.cs
+++ b/AquaMai.Mods/UX/OneKeyRetrySkip.cs
@@ -56,6 +56,10 @@ public class OneKeyRetrySkip
             var traverse = Traverse.Create(__instance);
             ___container.processManager.SendMessage(____message[0]);
             Singleton<GamePlayManager>.Instance.SetSyncResult(0);
+            for (int i = 0; i < 2; i++)
+            {
+                Singleton<GamePlayManager>.Instance.GetGameScore(i)?.SetTrackSkip();
+            }
             traverse.Method("SetRelease").GetValue();
         }
 


### PR DESCRIPTION
只是设置一个flag。
游戏官方的正常track skip逻辑是会设置这个flag的，所以我们也应该设一下

## Summary by Sourcery

Bug Fixes:
- 通过为两个播放器设置曲目跳过标志，确保一键重试跳过功能能正确地将曲目标记为已跳过。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure one-key retry skip correctly marks tracks as skipped by setting the track skip flag for both players.

</details>