### PR TITLE
[F] CI有时会由于各个子模块的编译顺序紊乱而炸掉。

### DIFF
--- a/AquaMai/AquaMai.csproj
+++ b/AquaMai/AquaMai.csproj
@@ -37,6 +37,14 @@
     <ProjectReference Include="../AquaMai.Config/AquaMai.Config.csproj" />
     <ProjectReference Include="../AquaMai.Core/AquaMai.Core.csproj" />
     <ProjectReference Include="../AquaMai.Mods/AquaMai.Mods.csproj" />
+
+    <!-- Build-order-only references: not linked, but ensure AquaMai.Build and AquaMai.ErrorReport's building finish before the main project. Otherwise, the build may fail. -->
+    <ProjectReference Include="../AquaMai.Build/AquaMai.Build.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true" />
+    <ProjectReference Include="../AquaMai.ErrorReport/AquaMai.ErrorReport.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
CI有时会概率性的由于各个子模块的编译顺序紊乱而炸掉，例如 https://github.com/MuNET-OSS/AquaMai/actions/runs/26497616326/job/78029596624

这个commit尝试以不改变原本build行为、不向主项目中产生额外内容的方式，添加了编译顺序上的约束，确保Build和ErrorReport子项目先于主项目编译。

本地测试表明生成的AquaMai.dll并无明显体积增大，然后游戏也能正常运行和打上patch。

## Summary by Sourcery

Build:
- 调整项目构建配置，确保在不更改运行时行为的前提下，使 Build 和 ErrorReport 子模块在主 AquaMai 项目之前编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Adjust project build configuration to ensure Build and ErrorReport submodules compile before the main AquaMai project without altering runtime behavior.

</details>