### PR TITLE
[+] 给一键重试和练习模式添加`onlyInFreedomMode`选项

### DIFF
--- a/AquaMai.Mods/UX/OneKeyRetrySkip.cs
+++ b/AquaMai.Mods/UX/OneKeyRetrySkip.cs
@@ -29,7 +29,19 @@ public class OneKeyRetrySkip
     [ConfigEntry("跳关长按")]
     public static readonly bool skipLongPress = true;
 
+    [ConfigEntry(
+        name: "仅自由模式可重开",
+        en: "Only allow retry in Freedom Mode while time remains.",
+        zh: "仅在自由模式且时间未耗尽时允许一键重试，跳过不受影响")]
+    public static readonly bool allowRetryOnlyInFreedomMode = false;
+
     private static bool dirty = false;
+
+    private static bool IsRetryAllowed()
+    {
+        if (!allowRetryOnlyInFreedomMode) return true;
+        return GameManager.IsFreedomMode && GameManager.GetFreedomModeMSec() > 0;
+    }
 
     [HarmonyPostfix]
     [HarmonyPatch(typeof(GameProcess), "OnStart")]
@@ -63,7 +75,8 @@ public class OneKeyRetrySkip
             traverse.Method("SetRelease").GetValue();
         }
 
-        else if (KeyListener.GetKeyDownOrLongPress(retryKey, retryLongPress) && GameInfo.GameVersion >= 23000)
+        else if (KeyListener.GetKeyDownOrLongPress(retryKey, retryLongPress) && GameInfo.GameVersion >= 23000 && 
+                 IsRetryAllowed())
         {
 #if DEBUG
             MelonLogger.Msg("[OneKeyRetrySkip] Retry key pressed.");

--- a/AquaMai.Mods/UX/PracticeMode/Libs/PractiseModeUI.cs
+++ b/AquaMai.Mods/UX/PracticeMode/Libs/PractiseModeUI.cs
@@ -98,11 +98,7 @@ public class PracticeModeUI : MonoBehaviour
         }
         else if (InputManager.GetTouchPanelAreaDown(InputManager.TouchPanelArea.B8) || InputManager.GetTouchPanelAreaDown(InputManager.TouchPanelArea.B1))
         {
-            DebugFeature.Pause = !DebugFeature.Pause;
-            if (!DebugFeature.Pause)
-            {
-                PracticeMode.Seek(0);
-            }
+            PracticeMode.TogglePause();
         }
         else if (InputManager.GetTouchPanelAreaDown(InputManager.TouchPanelArea.B7) && PracticeMode.repeatStart == -1)
         {

--- a/AquaMai.Mods/UX/PracticeMode/PracticeMode.cs
+++ b/AquaMai.Mods/UX/PracticeMode/PracticeMode.cs
@@ -36,6 +36,12 @@ public class PracticeMode
     [ConfigEntry]
     public static readonly bool longPress = false;
 
+    [ConfigEntry(
+        name: "仅自由模式可用",
+        en: "Only allow Practice Mode in Freedom Mode while time remains.",
+        zh: "仅在自由模式且时间未耗尽时允许使用练习模式")]
+    public static readonly bool onlyInFreedomMode = false;
+
     public static double repeatStart = -1;
     public static double repeatEnd = -1;
     public static float speed = 1;
@@ -43,6 +49,19 @@ public class PracticeMode
     private static List<MovieMaterialMai2> movie;
     private static GameCtrl[] gameCtrl = new GameCtrl[2];
     public static bool keepNoteSpeed = false;
+    
+    private static void ClearPracticeEffects()
+    {
+        // 清除练习模式的所有效果。涉及的效果有四种：UI界面、循环、速度、暂停。
+        if (ui != null)
+        {
+            UnityEngine.Object.Destroy(ui);
+            ui = null;
+        }
+        if (repeatStart >= 0 || repeatEnd >= 0) ClearRepeat();
+        if (speed != 1f) SpeedReset();
+        if (DebugFeature.Pause) TogglePause();
+    }
 
     public static void SetRepeatEnd(double time)
     {
@@ -178,6 +197,8 @@ public class PracticeMode
 
     public static PracticeModeUI ui;
 
+    private static long prevFreedomModeMSec = -1; // 上一帧时，自由模式的剩余秒数
+
     [HarmonyPatch]
     public class PatchNoteSpeed
     {
@@ -201,7 +222,9 @@ public class PracticeMode
         repeatStart = -1;
         repeatEnd = -1;
         speed = 1;
+        keepNoteSpeed = false;
         ui = null;
+        if (GameManager.IsFreedomMode) prevFreedomModeMSec = GameManager.GetFreedomModeMSec();
     }
 
     [HarmonyPatch(typeof(GameProcess), "OnRelease")]
@@ -211,6 +234,7 @@ public class PracticeMode
         repeatStart = -1;
         repeatEnd = -1;
         speed = 1;
+        keepNoteSpeed = false;
         ui = null;
     }
 
@@ -237,9 +261,18 @@ public class PracticeMode
     [HarmonyPostfix]
     public static void GameProcessPostUpdate(GameProcess __instance, GameMonitor[] ____monitors)
     {
-        if (KeyListener.GetKeyDownOrLongPress(key, longPress) && ui is null)
+        if (KeyListener.GetKeyDownOrLongPress(key, longPress) && ui is null && 
+            (!onlyInFreedomMode || (GameManager.IsFreedomMode && GameManager.GetFreedomModeMSec() > 0))) // onlyInFreedomMode=true情况，则额外检查是否在练习模式内、且时间有剩余，如果不满足则不开启UI。
         {
             ui = ____monitors[0].gameObject.AddComponent<PracticeModeUI>();
+        }
+        
+        if (onlyInFreedomMode && GameManager.IsFreedomMode)
+        {
+            var currentFreedomModeMSec = GameManager.GetFreedomModeMSec();
+            if (prevFreedomModeMSec > 0 && currentFreedomModeMSec <= 0)
+                ClearPracticeEffects(); // 如果这一帧内、练习模式的时间刚好归零了：则清空练习模式的一切效果。
+            prevFreedomModeMSec = currentFreedomModeMSec;
         }
 
         if (repeatStart >= 0 && repeatEnd >= 0)

--- a/AquaMai.Mods/UX/PracticeMode/PracticeMode.cs
+++ b/AquaMai.Mods/UX/PracticeMode/PracticeMode.cs
@@ -67,6 +67,15 @@ public class PracticeMode
         repeatEnd = -1;
     }
 
+    public static void TogglePause()
+    {
+        DebugFeature.Pause = !DebugFeature.Pause;
+        if (!DebugFeature.Pause)
+        {
+            Seek(0);
+        }
+    }
+
     public static void GameCtrlResetOptionSpeed()
     {
         foreach (var g in gameCtrl)

--- a/AquaMai.Mods/UX/PracticeMode/PracticeMode.cs
+++ b/AquaMai.Mods/UX/PracticeMode/PracticeMode.cs
@@ -52,13 +52,14 @@ public class PracticeMode
     
     private static void ClearPracticeEffects()
     {
-        // 清除练习模式的所有效果。涉及的效果有四种：UI界面、循环、速度、暂停。
+        // 清除练习模式的所有效果。涉及的效果有五种：UI界面、循环、速度保持、速度、暂停。
         if (ui != null)
         {
             UnityEngine.Object.Destroy(ui);
             ui = null;
         }
         if (repeatStart >= 0 || repeatEnd >= 0) ClearRepeat();
+        keepNoteSpeed = false;
         if (speed != 1f) SpeedReset();
         if (DebugFeature.Pause) TogglePause();
     }
@@ -224,7 +225,7 @@ public class PracticeMode
         speed = 1;
         keepNoteSpeed = false;
         ui = null;
-        if (GameManager.IsFreedomMode) prevFreedomModeMSec = GameManager.GetFreedomModeMSec();
+        prevFreedomModeMSec = GameManager.IsFreedomMode ? GameManager.GetFreedomModeMSec() : -1;
     }
 
     [HarmonyPatch(typeof(GameProcess), "OnRelease")]
@@ -236,6 +237,7 @@ public class PracticeMode
         speed = 1;
         keepNoteSpeed = false;
         ui = null;
+        prevFreedomModeMSec = -1;
     }
 
     [HarmonyPatch(typeof(GameCtrl), "Initialize")]


### PR DESCRIPTION
本PR给一键重试和练习模式功能，添加`onlyInFreedomMode`选项，默认不开启。当该选项开启时，上述功能仅在练习模式且时间有剩余的情况下才启用。具体而言：
1. 对一键重试，上述选项开启后，普通模式下和练习模式但时间耗尽后，都不能使用。
2. 对练习模式，上述选项开启后：
   - 首先同上，练习模式的UI只有在练习模式且时间有剩余情况下，才能开启UI。其他情况下无法开启UI。
   - 此外，在练习模式的时间耗尽时，会强制清除练习模式的一切效果（解除循环/恢复原速/解除暂停/关闭UI）。

本PR主要是适配窝的需求，因为会存在着使用上述功能”霸机“的情况，比如一直不停的重开Retry，或者用练习模式拖时间等等。

## Summary by Sourcery

为练习模式和一键重试添加配置选项，使其仅在激活的自由模式会话中可用，并在时间到期时重置练习效果。

新功能：
- 引入 `onlyInFreedomMode` 选项，将练习模式的使用限制为仅在有剩余时间的自由模式中可用。
- 添加 `allowRetryOnlyInFreedomMode` 选项，将一键重试限制为仅在有剩余时间的自由模式中可用。

增强内容：
- 当自由模式时间耗尽时，重置练习模式状态并清除所有练习效果，包括 UI、循环、速度变化和暂停。
- 通过新的 `TogglePause` 辅助函数集中管理练习模式的暂停切换逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configuration options to restrict Practice Mode and one-key retry to active Freedom Mode sessions and reset practice effects when time expires.

New Features:
- Introduce an onlyInFreedomMode option to gate Practice Mode usage to Freedom Mode with remaining time.
- Add an allowRetryOnlyInFreedomMode option to restrict one-key retry to Freedom Mode with remaining time.

Enhancements:
- Reset Practice Mode state and clear all practice effects, including UI, looping, speed changes, and pause, when Freedom Mode time runs out.
- Centralize Practice Mode pause toggling logic via a new TogglePause helper.

</details>