### PR TITLE
[F] #134中引入了一个副作用，错误的使得`keepNoteSpeed`不再跨歌曲保存了。

### DIFF
--- a/AquaMai.Mods/UX/PracticeMode/PracticeMode.cs
+++ b/AquaMai.Mods/UX/PracticeMode/PracticeMode.cs
@@ -52,14 +52,13 @@ public class PracticeMode
     
     private static void ClearPracticeEffects()
     {
-        // 清除练习模式的所有效果。涉及的效果有五种：UI界面、循环、速度保持、速度、暂停。
+        // 清除练习模式的所有效果。涉及的效果有四种：UI界面、循环、速度、暂停。
         if (ui != null)
         {
             UnityEngine.Object.Destroy(ui);
             ui = null;
         }
         if (repeatStart >= 0 || repeatEnd >= 0) ClearRepeat();
-        keepNoteSpeed = false;
         if (speed != 1f) SpeedReset();
         if (DebugFeature.Pause) TogglePause();
     }
@@ -223,7 +222,6 @@ public class PracticeMode
         repeatStart = -1;
         repeatEnd = -1;
         speed = 1;
-        keepNoteSpeed = false;
         ui = null;
         prevFreedomModeMSec = GameManager.IsFreedomMode ? GameManager.GetFreedomModeMSec() : -1;
     }
@@ -235,7 +233,6 @@ public class PracticeMode
         repeatStart = -1;
         repeatEnd = -1;
         speed = 1;
-        keepNoteSpeed = false;
         ui = null;
         prevFreedomModeMSec = -1;
     }


### PR DESCRIPTION
大概是写的时候脑抽了， 332210b 又被Review Bot误导了一下，导致写出了个副作用

虽然其实也不严重，就是以前的时候，保持流速这个选项，是可以跨track传递的，第一track开了保持流速，第二track打开之后还是开着的；但是这个commit不慎把这个行为给覆盖了，导致保持流速的选项无法再跨track传递了。但最好还是稍微修一下。

而保持流速这个，其实只是个flag；在speed为1也就是没变速的情况下，是没有任何作用的。所以`ClearPracticeEffects`其实并不需要把保持流速关掉

加上此fix后，已通过静态分析确认，#134 新引入的`onlyForFreedomMode`选项，在默认值false的情况下不会改变任何旧有行为。