### PR TITLE
微调了“隐藏曲目信息”的表现

### DIFF
--- a/AquaMai.Mods/Fancy/GamePlay/DisableTrackStartTabs.cs
+++ b/AquaMai.Mods/Fancy/GamePlay/DisableTrackStartTabs.cs
@@ -40,14 +40,14 @@ public class DisableTrackStartTabs
         ____musicTabObj[2].gameObject.SetActive(false);
         ____derakkumaRoot.SetActive(false);
         var traverse = Traverse.Create(____musicDetail);
-        traverse.Field<MultipleImage>("_achivement_Base").Value.ChangeSprite(1);
-        traverse.Field<MultipleImage>("_clearRank_Base").Value.ChangeSprite(1);
+        traverse.Field<MultipleImage>("_achivement_Base").Value.gameObject.SetActive(false);
+        traverse.Field<MultipleImage>("_clearRank_Base").Value.gameObject.SetActive(false);
         traverse.Field<TextMeshProUGUI>("_achivement_Text").Value.gameObject.SetActive(false);
         traverse.Field<TextMeshProUGUI>("_achivement_decimal_Text").Value.gameObject.SetActive(false);
         traverse.Field<TextMeshProUGUI>("_achivement_percent_Text").Value.gameObject.SetActive(false);
         traverse.Field<MultipleImage>("_clearRank_Image").Value.gameObject.SetActive(false);
         traverse.Field<GameObject>("_deluxScore_Obj").Value.SetActive(false);
-        traverse.Field<MultipleImage>("_comboRank_Image").Value.ChangeSprite(0);
-        traverse.Field<MultipleImage>("_syncRank_Image").Value.ChangeSprite(0);
+        traverse.Field<MultipleImage>("_comboRank_Image").Value.gameObject.SetActive(false);
+        traverse.Field<MultipleImage>("_syncRank_Image").Value.gameObject.SetActive(false);
     }
 }


### PR DESCRIPTION
原来打开这个功能以后用来展示历史分数的框会保留一个默认图像，改成了直接隐藏掉整个框

## Summary by Sourcery

增强内容：
- 当赛道信息被隐藏时，通过禁用默认成就和段位图片的 GameObject，而不是替换精灵（sprite），从赛道开始面板中移除这些默认成就和段位图片。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove default achievement and rank images from the track start panel when track information is hidden by disabling their GameObjects instead of swapping sprites.

</details>